### PR TITLE
(#10) feat: Remember me（ログイン状態を維持する）機能を実装

### DIFF
--- a/src/app/(auth)/login/actions.ts
+++ b/src/app/(auth)/login/actions.ts
@@ -1,0 +1,44 @@
+"use server";
+
+import {
+  createRememberToken,
+  deleteRememberToken,
+} from "@/lib/auth/remember-me";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * Remember meトークンを作成（ログイン成功後に呼び出し）
+ */
+export async function setRememberMeToken(): Promise<{ success: boolean }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { success: false };
+  }
+
+  await createRememberToken(user.id);
+  return { success: true };
+}
+
+/**
+ * ログアウト処理（Supabaseログアウト + Remember meトークン削除）
+ */
+export async function logout(): Promise<{ success: boolean }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    // Remember meトークンを削除
+    await deleteRememberToken(user.id);
+  }
+
+  // Supabaseからログアウト
+  await supabase.auth.signOut();
+
+  return { success: true };
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -4,11 +4,13 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
+import { setRememberMeToken } from "./actions";
 
 export default function LoginPage() {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [rememberMe, setRememberMe] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -27,6 +29,11 @@ export default function LoginPage() {
       setError(error.message);
       setLoading(false);
       return;
+    }
+
+    // Remember meがチェックされていたらトークンを発行
+    if (rememberMe) {
+      await setRememberMeToken();
     }
 
     router.push("/");
@@ -92,6 +99,18 @@ export default function LoginPage() {
                 >
                   パスワードをお忘れですか？
                 </Link>
+              </label>
+            </div>
+
+            <div className="form-control">
+              <label className="label cursor-pointer justify-start gap-3">
+                <input
+                  type="checkbox"
+                  className="checkbox checkbox-primary checkbox-sm"
+                  checked={rememberMe}
+                  onChange={(e) => setRememberMe(e.target.checked)}
+                />
+                <span className="label-text">ログイン状態を維持する</span>
               </label>
             </div>
 

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 import { createClient } from "@/lib/supabase/client";
+import { logout } from "@/app/(auth)/login/actions";
 import type { User } from "@supabase/supabase-js";
 
 const navItems = [
@@ -15,6 +16,7 @@ const navItems = [
 
 export function Navigation() {
   const pathname = usePathname();
+  const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -144,7 +146,8 @@ export function Navigation() {
                   <li>
                     <button
                       onClick={async () => {
-                        await supabase.auth.signOut();
+                        await logout();
+                        router.refresh();
                       }}
                       className="text-gray-700 hover:bg-yellow-100"
                     >

--- a/src/lib/auth/remember-me.ts
+++ b/src/lib/auth/remember-me.ts
@@ -1,0 +1,202 @@
+import { db } from "@/lib/db";
+import { rememberTokens, users } from "@/lib/db/schema";
+import { eq, and, gt } from "drizzle-orm";
+import { cookies } from "next/headers";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { NextRequest } from "next/server";
+
+export const REMEMBER_TOKEN_COOKIE_NAME = "remember_token";
+const TOKEN_EXPIRY_DAYS = 30;
+
+/**
+ * ランダムトークンを生成（32バイト = 256bit）
+ */
+async function generateToken(): Promise<string> {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join(
+    ""
+  );
+}
+
+/**
+ * トークンをSHA-256でハッシュ化
+ */
+async function hashToken(token: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(token);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Remember meトークンを生成してDBとCookieに保存
+ */
+export async function createRememberToken(userId: string): Promise<void> {
+  // 既存のトークンを削除（1ユーザー1トークン）
+  await db.delete(rememberTokens).where(eq(rememberTokens.userId, userId));
+
+  // 新しいトークンを生成
+  const token = await generateToken();
+  const tokenHash = await hashToken(token);
+  const expiresAt = new Date();
+  expiresAt.setDate(expiresAt.getDate() + TOKEN_EXPIRY_DAYS);
+
+  // DBに保存
+  await db.insert(rememberTokens).values({
+    userId,
+    tokenHash,
+    expiresAt,
+  });
+
+  // Cookieに保存
+  const cookieStore = await cookies();
+  cookieStore.set(REMEMBER_TOKEN_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: TOKEN_EXPIRY_DAYS * 24 * 60 * 60, // 30日（秒）
+    path: "/",
+  });
+}
+
+/**
+ * Remember meトークンを検証してユーザー情報を取得
+ */
+export async function validateRememberToken(): Promise<{
+  userId: string;
+  email: string;
+} | null> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(REMEMBER_TOKEN_COOKIE_NAME)?.value;
+
+  if (!token) {
+    return null;
+  }
+
+  const tokenHash = await hashToken(token);
+  const now = new Date();
+
+  // DBからトークンを検索（有効期限内のもの）
+  const [record] = await db
+    .select({
+      userId: rememberTokens.userId,
+      email: users.email,
+    })
+    .from(rememberTokens)
+    .innerJoin(users, eq(rememberTokens.userId, users.id))
+    .where(
+      and(
+        eq(rememberTokens.tokenHash, tokenHash),
+        gt(rememberTokens.expiresAt, now)
+      )
+    );
+
+  if (!record) {
+    // 無効なトークンはCookieから削除
+    cookieStore.delete(REMEMBER_TOKEN_COOKIE_NAME);
+    return null;
+  }
+
+  return { userId: record.userId, email: record.email };
+}
+
+/**
+ * Remember meトークンを削除（ログアウト時に使用）
+ */
+export async function deleteRememberToken(userId: string): Promise<void> {
+  // DBから削除
+  await db.delete(rememberTokens).where(eq(rememberTokens.userId, userId));
+
+  // Cookieから削除
+  const cookieStore = await cookies();
+  cookieStore.delete(REMEMBER_TOKEN_COOKIE_NAME);
+}
+
+/**
+ * ミドルウェア用: Remember meトークンを検証してユーザー情報を取得
+ * NextRequestのcookiesを直接使用
+ */
+export async function validateRememberTokenFromRequest(
+  request: NextRequest
+): Promise<{
+  userId: string;
+  email: string;
+} | null> {
+  const token = request.cookies.get(REMEMBER_TOKEN_COOKIE_NAME)?.value;
+
+  if (!token) {
+    return null;
+  }
+
+  const tokenHash = await hashToken(token);
+  const now = new Date();
+
+  // DBからトークンを検索（有効期限内のもの）
+  const [record] = await db
+    .select({
+      userId: rememberTokens.userId,
+      email: users.email,
+    })
+    .from(rememberTokens)
+    .innerJoin(users, eq(rememberTokens.userId, users.id))
+    .where(
+      and(
+        eq(rememberTokens.tokenHash, tokenHash),
+        gt(rememberTokens.expiresAt, now)
+      )
+    );
+
+  if (!record) {
+    return null;
+  }
+
+  return { userId: record.userId, email: record.email };
+}
+
+/**
+ * トークンローテーション（セキュリティ向上のため、使用後に新しいトークンを発行）
+ */
+export async function rotateRememberToken(userId: string): Promise<void> {
+  await createRememberToken(userId);
+}
+
+/**
+ * Admin APIを使用してSupabaseセッションを発行
+ * マジックリンクを生成し、そのトークンでセッションを作成
+ */
+export async function createSupabaseSessionForUser(email: string): Promise<{
+  access_token: string;
+  refresh_token: string;
+} | null> {
+  const supabaseAdmin = createAdminClient();
+
+  // マジックリンクを生成（実際には送信せず、トークンのみ取得）
+  const { data, error } = await supabaseAdmin.auth.admin.generateLink({
+    type: "magiclink",
+    email,
+  });
+
+  if (error || !data) {
+    console.error("Failed to generate magic link:", error);
+    return null;
+  }
+
+  // 生成されたトークンでセッションを確立
+  const { data: sessionData, error: sessionError } =
+    await supabaseAdmin.auth.verifyOtp({
+      token_hash: data.properties.hashed_token,
+      type: "magiclink",
+    });
+
+  if (sessionError || !sessionData.session) {
+    console.error("Failed to verify OTP:", sessionError);
+    return null;
+  }
+
+  return {
+    access_token: sessionData.session.access_token,
+    refresh_token: sessionData.session.refresh_token,
+  };
+}

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -7,3 +7,4 @@ export * from "./beers";
 export * from "./reviews";
 export * from "./favorites";
 export * from "./style-requests";
+export * from "./remember-tokens";

--- a/src/lib/db/schema/remember-tokens.ts
+++ b/src/lib/db/schema/remember-tokens.ts
@@ -1,0 +1,15 @@
+import { pgTable, serial, uuid, text, timestamp } from "drizzle-orm/pg-core";
+import { users } from "./users";
+
+export const rememberTokens = pgTable("remember_tokens", {
+  id: serial("id").primaryKey(),
+  userId: uuid("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  tokenHash: text("token_hash").notNull(),
+  expiresAt: timestamp("expires_at").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export type RememberToken = typeof rememberTokens.$inferSelect;
+export type NewRememberToken = typeof rememberTokens.$inferInsert;

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,18 @@
+import { createClient } from "@supabase/supabase-js";
+
+/**
+ * Admin権限を持つSupabaseクライアント（サーバーサイド専用）
+ * RLSをバイパスできるため、取り扱い注意
+ */
+export function createAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    }
+  );
+}


### PR DESCRIPTION
close #10 

- ログインページに「ログイン状態を維持する」チェックボックスを追加
- チェックありでログイン時、30日間有効なRemember meトークンを発行
- セッション切れ時、トークンがあれば自動的にSupabaseセッションを再発行
- ログアウト時にRemember meトークンも削除

新規ファイル:
- src/lib/supabase/admin.ts: Supabase Admin Client
- src/lib/db/schema/remember-tokens.ts: トークンDBスキーマ
- src/lib/auth/remember-me.ts: トークン処理関数
- src/app/(auth)/login/actions.ts: ログイン/ログアウトServer Action

🤖 Generated with [Claude Code](https://claude.com/claude-code)