### PR TITLE
issue/3 ビール、ブルワリー、スタイル一覧に30件ごとのページネーションを追加

### DIFF
--- a/src/components/ui/Pagination.tsx
+++ b/src/components/ui/Pagination.tsx
@@ -1,0 +1,160 @@
+import Link from "next/link";
+
+const ITEMS_PER_PAGE = 30;
+
+interface PaginationProps {
+  currentPage: number;
+  totalCount: number;
+  basePath: string;
+  searchParams?: Record<string, string | undefined>;
+}
+
+function buildUrl(
+  basePath: string,
+  page: number,
+  searchParams?: Record<string, string | undefined>
+): string {
+  const params = new URLSearchParams();
+
+  // 既存の検索パラメータを追加
+  if (searchParams) {
+    Object.entries(searchParams).forEach(([key, value]) => {
+      if (value && key !== "page") {
+        params.set(key, value);
+      }
+    });
+  }
+
+  // ページ番号を追加（1ページ目は省略）
+  if (page > 1) {
+    params.set("page", String(page));
+  }
+
+  const queryString = params.toString();
+  return queryString ? `${basePath}?${queryString}` : basePath;
+}
+
+export function Pagination({
+  currentPage,
+  totalCount,
+  basePath,
+  searchParams,
+}: PaginationProps) {
+  const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE);
+
+  // 1ページ以下の場合は表示しない
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  // 表示するページ番号を計算（現在ページを中心に最大5ページ）
+  const getPageNumbers = (): number[] => {
+    const pages: number[] = [];
+    const maxVisible = 5;
+    let start = Math.max(1, currentPage - Math.floor(maxVisible / 2));
+    const end = Math.min(totalPages, start + maxVisible - 1);
+
+    // 終端に達した場合は開始位置を調整
+    if (end - start + 1 < maxVisible) {
+      start = Math.max(1, end - maxVisible + 1);
+    }
+
+    for (let i = start; i <= end; i++) {
+      pages.push(i);
+    }
+    return pages;
+  };
+
+  const pageNumbers = getPageNumbers();
+  const startItem = (currentPage - 1) * ITEMS_PER_PAGE + 1;
+  const endItem = Math.min(currentPage * ITEMS_PER_PAGE, totalCount);
+
+  return (
+    <div className="flex flex-col items-center gap-4 mt-8">
+      {/* 件数表示 */}
+      <p className="text-sm text-base-content/70">
+        全{totalCount}件中 {startItem}-{endItem}件を表示
+      </p>
+
+      {/* ページネーションボタン */}
+      <div className="join">
+        {/* 前へボタン */}
+        {currentPage > 1 ? (
+          <Link
+            href={buildUrl(basePath, currentPage - 1, searchParams)}
+            className="join-item btn btn-sm"
+          >
+            «
+          </Link>
+        ) : (
+          <button className="join-item btn btn-sm btn-disabled" disabled>
+            «
+          </button>
+        )}
+
+        {/* 最初のページ（省略記号付き） */}
+        {pageNumbers[0] > 1 && (
+          <>
+            <Link
+              href={buildUrl(basePath, 1, searchParams)}
+              className="join-item btn btn-sm"
+            >
+              1
+            </Link>
+            {pageNumbers[0] > 2 && (
+              <button className="join-item btn btn-sm btn-disabled" disabled>
+                ...
+              </button>
+            )}
+          </>
+        )}
+
+        {/* ページ番号 */}
+        {pageNumbers.map((page) => (
+          <Link
+            key={page}
+            href={buildUrl(basePath, page, searchParams)}
+            className={`join-item btn btn-sm ${
+              page === currentPage ? "btn-active" : ""
+            }`}
+          >
+            {page}
+          </Link>
+        ))}
+
+        {/* 最後のページ（省略記号付き） */}
+        {pageNumbers[pageNumbers.length - 1] < totalPages && (
+          <>
+            {pageNumbers[pageNumbers.length - 1] < totalPages - 1 && (
+              <button className="join-item btn btn-sm btn-disabled" disabled>
+                ...
+              </button>
+            )}
+            <Link
+              href={buildUrl(basePath, totalPages, searchParams)}
+              className="join-item btn btn-sm"
+            >
+              {totalPages}
+            </Link>
+          </>
+        )}
+
+        {/* 次へボタン */}
+        {currentPage < totalPages ? (
+          <Link
+            href={buildUrl(basePath, currentPage + 1, searchParams)}
+            className="join-item btn btn-sm"
+          >
+            »
+          </Link>
+        ) : (
+          <button className="join-item btn btn-sm btn-disabled" disabled>
+            »
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export { ITEMS_PER_PAGE };


### PR DESCRIPTION
## 概要

ビール一覧、ブルワリー一覧、スタイル一覧ページに30件ごとのページネーション機能を追加。

Closes #3

## 変更内容

- 共通ページネーションコンポーネント（`Pagination.tsx`）を新規作成
  - DaisyUI の join コンポーネントを使用
  - URLパラメータ（`page`）でページ遷移
  - フィルター条件を維持したままページ遷移可能
- ビール一覧（`/beers`）にページネーションを追加
- ブルワリー一覧（`/breweries`）にページネーションを追加
- スタイル一覧（`/styles`）にページネーションを追加
  - キーワード検索をサーバーサイドに移行（別名検索含む）

## 確認事項

- [x] ビルドが通ること
- [x] Server Component として実装（SEO対策）

## テスト

- [x] ビール一覧で2ページ目以降に遷移できること
- [x] ブルワリー一覧で2ページ目以降に遷移できること
- [x] スタイル一覧で2ページ目以降に遷移できること
- [x] フィルター適用中にページ遷移してもフィルターが維持されること
- [x] 件数表示（全XX件中 1-30件を表示）が正しいこと
