### PR TITLE
issue/45 ビール追加機能を会員限定に変更

### DIFF
--- a/src/app/beers/[id]/page.tsx
+++ b/src/app/beers/[id]/page.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import { FlavorProfile, FavoriteButton, BeerCard } from "@/components/beer";
 import { BeerFilter } from "@/components/beer/BeerFilter";
 import { ReviewCard } from "@/components/review/ReviewCard";
+import { AuthRequiredLink } from "@/components/ui/AuthRequiredLink";
 import { createClient } from "@/lib/supabase/server";
 import type { Metadata } from "next";
 
@@ -148,6 +149,11 @@ export default async function BeerPage({ params }: Props) {
 
 // フィルターページコンポーネント
 async function FilteredBeersPage({ filterType, filterId }: { filterType: "style" | "brewery"; filterId: number }) {
+  // 認証状態を取得
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  const isAuthenticated = !!user;
+
   let filterName = "";
   let styleSlug: string | null = null;
 
@@ -282,9 +288,13 @@ async function FilteredBeersPage({ filterType, filterId }: { filterType: "style"
             {filterType === "style" ? "スタイル" : "ブルワリー"}で絞り込み中
           </span>
         </div>
-        <Link href="/submit/beer" className="btn btn-primary btn-sm">
+        <AuthRequiredLink
+          href="/submit/beer"
+          isAuthenticated={isAuthenticated}
+          className="btn btn-primary btn-sm"
+        >
           + ビールを追加
-        </Link>
+        </AuthRequiredLink>
       </div>
 
       {/* ビール一覧 */}
@@ -300,9 +310,13 @@ async function FilteredBeersPage({ filterType, filterId }: { filterType: "style"
           <p className="text-lg text-base-content/60 mb-4">
             {filterName}のビールはまだ登録されていません
           </p>
-          <Link href="/submit/beer" className="btn btn-primary">
+          <AuthRequiredLink
+            href="/submit/beer"
+            isAuthenticated={isAuthenticated}
+            className="btn btn-primary"
+          >
             最初のビールを登録する
-          </Link>
+          </AuthRequiredLink>
         </div>
       )}
     </div>

--- a/src/app/beers/page.tsx
+++ b/src/app/beers/page.tsx
@@ -1,10 +1,11 @@
 import { db } from "@/lib/db";
 import { beers, breweries, beerStyles } from "@/lib/db/schema";
 import { eq, and, ilike, or, count } from "drizzle-orm";
+import { createClient } from "@/lib/supabase/server";
 import { BeerCard } from "@/components/beer";
 import { BeerFilter } from "@/components/beer/BeerFilter";
 import { Pagination, ITEMS_PER_PAGE } from "@/components/ui/Pagination";
-import Link from "next/link";
+import { AuthRequiredLink } from "@/components/ui/AuthRequiredLink";
 
 export const metadata = {
   title: "ビール一覧 | beer_link",
@@ -27,6 +28,11 @@ interface Props {
 export default async function BeersPage({ searchParams }: Props) {
   const params = await searchParams;
   const { q, style, brewery } = params;
+
+  // 認証状態を取得
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  const isAuthenticated = !!user;
 
   // ページ番号を取得（デフォルト: 1）
   const currentPage = Math.max(1, parseInt(params.page || "1", 10) || 1);
@@ -134,9 +140,13 @@ export default async function BeersPage({ searchParams }: Props) {
             </span>
           )}
         </div>
-        <Link href="/submit/beer" className="btn btn-primary btn-sm">
+        <AuthRequiredLink
+          href="/submit/beer"
+          isAuthenticated={isAuthenticated}
+          className="btn btn-primary btn-sm"
+        >
           + ビールを追加
-        </Link>
+        </AuthRequiredLink>
       </div>
 
       {/* ビール一覧 */}

--- a/src/app/submit/beer/page.tsx
+++ b/src/app/submit/beer/page.tsx
@@ -1,6 +1,8 @@
 import { db } from "@/lib/db";
 import { breweries, beerStyles, beerStyleOtherNames } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
 import { BeerSubmitForm } from "./BeerSubmitForm";
 import type { Metadata } from "next";
 
@@ -13,6 +15,14 @@ export const metadata: Metadata = {
 export const dynamic = "force-dynamic";
 
 export default async function BeerSubmitPage() {
+  // 認証チェック
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
   // ブルワリー一覧を取得（承認済みのみ）
   const breweryList = await db
     .select({ id: breweries.id, name: breweries.name })

--- a/src/app/submit/brewery/page.tsx
+++ b/src/app/submit/brewery/page.tsx
@@ -1,3 +1,5 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
 import { BrewerySubmitForm } from "./BrewerySubmitForm";
 import type { Metadata } from "next";
 
@@ -6,7 +8,18 @@ export const metadata: Metadata = {
   description: "新しいブルワリーを追加できます",
 };
 
-export default function BrewerySubmitPage() {
+// 認証チェックのため動的レンダリング
+export const dynamic = "force-dynamic";
+
+export default async function BrewerySubmitPage() {
+  // 認証チェック
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="max-w-md mx-auto">

--- a/src/app/submit/style/page.tsx
+++ b/src/app/submit/style/page.tsx
@@ -1,3 +1,5 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
 import { StyleSubmitForm } from "./StyleSubmitForm";
 import type { Metadata } from "next";
 
@@ -6,7 +8,18 @@ export const metadata: Metadata = {
   description: "新しいビアスタイルを追加できます",
 };
 
-export default function StyleSubmitPage() {
+// 認証チェックのため動的レンダリング
+export const dynamic = "force-dynamic";
+
+export default async function StyleSubmitPage() {
+  // 認証チェック
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="max-w-md mx-auto">

--- a/src/components/ui/AuthRequiredLink.tsx
+++ b/src/components/ui/AuthRequiredLink.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+interface AuthRequiredLinkProps {
+  href: string;
+  isAuthenticated: boolean;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function AuthRequiredLink({
+  href,
+  isAuthenticated,
+  children,
+  className,
+}: AuthRequiredLinkProps) {
+  const [showModal, setShowModal] = useState(false);
+
+  if (isAuthenticated) {
+    return (
+      <Link href={href} className={className}>
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setShowModal(true)}
+        className={className}
+      >
+        {children}
+      </button>
+
+      {showModal && (
+        <div className="modal modal-open">
+          <div className="modal-box">
+            <h3 className="font-bold text-lg">ログインが必要です</h3>
+            <p className="py-4">
+              この機能を使うには、ログインまたは会員登録が必要です。
+            </p>
+            <div className="modal-action">
+              <button
+                className="btn btn-ghost"
+                onClick={() => setShowModal(false)}
+              >
+                キャンセル
+              </button>
+              <Link href="/register" className="btn btn-outline btn-primary">
+                会員登録
+              </Link>
+              <Link href="/login" className="btn btn-primary">
+                ログイン
+              </Link>
+            </div>
+          </div>
+          <div
+            className="modal-backdrop"
+            onClick={() => setShowModal(false)}
+          ></div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## 概要

ビール・ブルワリー・スタイルの投稿機能を会員限定に変更しました。
未ログインユーザーには、ボタンクリック時にログイン/会員登録を促すモーダルを表示します。

Closes #45

## 変更内容

### 新規コンポーネント
- `AuthRequiredLink` - 認証状態に応じて動作を切り替えるリンクコンポーネント
  - ログイン済み：通常のリンクとして遷移
  - 未ログイン：モーダルでログイン/会員登録を促す

### ページ更新
- ビール一覧ページ（`/beers`）の「+ ビールを追加」ボタン
- ビール詳細ページ（`/beers/[id]`）の追加ボタン
- 投稿ページ（`/submit/*`）に認証チェック追加（直接アクセス対策）

## 確認事項

- [x] 未ログイン状態で「+ ビールを追加」ボタンをクリックするとモーダルが表示される
- [x] モーダルから「ログイン」「会員登録」ページに遷移できる
- [x] ログイン済みユーザーはボタンクリックで直接投稿ページに遷移する
- [x] 未ログインで `/submit/beer` に直接アクセスすると `/login` にリダイレクトされる
