### PR TITLE
issue/46 Google AdSense対応を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ NEXT_PUBLIC_R2_PUBLIC_URL=<your-r2-public-url>
 
 # Cloudflare R2 (静的アセット用)
 NEXT_PUBLIC_R2_ASSETS_URL=<your-r2-assets-url>
+
+# Google AdSense (任意)
+NEXT_PUBLIC_ADSENSE_CLIENT_ID=ca-pub-xxxxxxxxxxxxxxxx
+NEXT_PUBLIC_ADSENSE_SLOT_ID=xxxxxxxxxx
 ```
 
 ### 5. データベースのセットアップ

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import { Navigation } from "@/components/layout/Navigation";
 import { Footer } from "@/components/layout/Footer";
+import { FooterAd } from "@/components/ads";
 import { GoogleTagManager } from "@next/third-parties/google";
 import { BackgroundBubbles } from "@/components/layout/BackgroundBubbles";
 
@@ -71,10 +73,20 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const adsenseClientId = process.env.NEXT_PUBLIC_ADSENSE_CLIENT_ID;
+
   return (
     <html lang="ja">
       {process.env.NEXT_PUBLIC_GTM_ID && (
         <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />
+      )}
+      {adsenseClientId && (
+        <Script
+          async
+          src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${adsenseClientId}`}
+          crossOrigin="anonymous"
+          strategy="afterInteractive"
+        />
       )}
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
@@ -83,6 +95,7 @@ export default function RootLayout({
         <div className="min-h-screen flex flex-col relative z-10">
           <Navigation />
           <main className="flex-1">{children}</main>
+          <FooterAd />
           <Footer />
         </div>
       </body>

--- a/src/components/ads/AdSenseUnit.tsx
+++ b/src/components/ads/AdSenseUnit.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    adsbygoogle: unknown[];
+  }
+}
+
+interface AdSenseUnitProps {
+  slot: string;
+  format?: "auto" | "rectangle" | "horizontal" | "vertical";
+  responsive?: boolean;
+  className?: string;
+}
+
+export function AdSenseUnit({
+  slot,
+  format = "auto",
+  responsive = true,
+  className = "",
+}: AdSenseUnitProps) {
+  const clientId = process.env.NEXT_PUBLIC_ADSENSE_CLIENT_ID;
+
+  useEffect(() => {
+    if (!clientId) return;
+
+    try {
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+    } catch (error) {
+      console.error("AdSense error:", error);
+    }
+  }, [clientId]);
+
+  // AdSenseの設定がない場合は何も表示しない
+  if (!clientId || !slot) {
+    return null;
+  }
+
+  return (
+    <div className={`ad-container ${className}`}>
+      <ins
+        className="adsbygoogle"
+        style={{ display: "block" }}
+        data-ad-client={clientId}
+        data-ad-slot={slot}
+        data-ad-format={format}
+        data-full-width-responsive={responsive ? "true" : "false"}
+      />
+    </div>
+  );
+}

--- a/src/components/ads/FooterAd.tsx
+++ b/src/components/ads/FooterAd.tsx
@@ -1,0 +1,23 @@
+import { AdSenseUnit } from "./AdSenseUnit";
+
+export function FooterAd() {
+  const slotId = process.env.NEXT_PUBLIC_ADSENSE_SLOT_ID;
+
+  // スロットIDが設定されていない場合は何も表示しない
+  if (!slotId) {
+    return null;
+  }
+
+  return (
+    <div className="w-full bg-base-200/50 py-4">
+      <div className="container mx-auto px-4">
+        <AdSenseUnit
+          slot={slotId}
+          format="horizontal"
+          responsive={true}
+          className="max-w-4xl mx-auto"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ads/index.ts
+++ b/src/components/ads/index.ts
@@ -1,0 +1,2 @@
+export { AdSenseUnit } from "./AdSenseUnit";
+export { FooterAd } from "./FooterAd";

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -59,6 +59,7 @@ NEXT_PUBLIC_R2_ASSETS_URL = "https://r2-assets.beer-link.com"
 NEXT_PUBLIC_SUPABASE_URL = "https://dzxlhatxlpspjhzmipeh.supabase.co"
 NEXT_PUBLIC_SUPABASE_ANON_KEY = "sb_publishable_HlSP-NOxzMpYRguIEA1e7Q_8IefLKy2"
 NEXT_PUBLIC_GTM_ID = "GTM-KD497KSD"
+NEXT_PUBLIC_ADSENSE_CLIENT_ID = "ca-pub-8072275026982974"
 
 [[env.production.r2_buckets]]
 binding = "R2_BUCKET"


### PR DESCRIPTION
## 概要

Google AdSenseに対応し、各ページのフッター上に広告枠を1つ配置できるようにした。

Closes #46

## 変更内容

- `src/components/ads/` に広告コンポーネントを新規作成
  - `AdSenseUnit.tsx`: 広告ユニットの汎用コンポーネント
  - `FooterAd.tsx`: フッター用広告コンポーネント
- `layout.tsx` にAdSenseスクリプトとFooterAdを追加
- 本番環境の環境変数に `NEXT_PUBLIC_ADSENSE_CLIENT_ID` を設定
- READMEに環境変数の設定例を追加

## 設計方針

- 環境変数が未設定の場合は広告を一切表示しない
- ステージング/ローカルでは環境変数を設定しないことで広告を非表示にできる
- 審査通過後に `NEXT_PUBLIC_ADSENSE_SLOT_ID` を追加すれば広告が表示される

## 確認事項

- [x] ビルドが通ること
- [ ] 本番デプロイ後、AdSenseスクリプトが読み込まれること

## テスト

- [x] 環境変数未設定時に広告が表示されないこと
- [ ] AdSense審査通過後、広告が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
