### PR TITLE
issue/57 ブルワリーの住所表示を都道府県+住所に変更

### DIFF
--- a/src/app/admin/breweries/BreweryEditModal.tsx
+++ b/src/app/admin/breweries/BreweryEditModal.tsx
@@ -104,15 +104,20 @@ export function BreweryEditModal({ brewery, prefectures, onClose }: Props) {
           {/* 住所 */}
           <div className="form-control">
             <label className="label">
-              <span className="label-text">住所</span>
+              <span className="label-text">住所（都道府県以降）</span>
             </label>
             <input
               type="text"
               value={address}
               onChange={(e) => setAddress(e.target.value)}
               className="input input-bordered"
-              placeholder="〒000-0000 東京都..."
+              placeholder="〒000-0000 渋谷区..."
             />
+            <label className="label">
+              <span className="label-text-alt text-base-content/60">
+                都道府県は上で選択してください。表示時に自動で結合されます。
+              </span>
+            </label>
           </div>
 
           {/* Webサイト */}

--- a/src/app/breweries/[id]/page.tsx
+++ b/src/app/breweries/[id]/page.tsx
@@ -184,10 +184,12 @@ export default async function BreweryDetailPage({ params }: Props) {
 
           {/* 詳細情報 */}
           <div className="space-y-3">
-            {brewery.address && (
+            {(brewery.prefecture || brewery.address) && (
               <div className="flex items-start gap-2">
                 <span className="font-medium min-w-20">所在地:</span>
-                <span className="text-base-content/80">{brewery.address}</span>
+                <span className="text-base-content/80">
+                  {brewery.prefecture?.name}{brewery.address}
+                </span>
               </div>
             )}
             {brewery.websiteUrl && (


### PR DESCRIPTION
## 概要

ブルワリーの住所入力・表示方法を改善し、都道府県と住所を分離して管理するようにした。

Closes #59

## 変更内容

- 管理画面の住所入力欄を「都道府県以降」のみ入力するよう案内を追加
- 詳細ページで都道府県+住所を結合して表示（例: 東京都渋谷区...）

## 確認事項

- [x] 既存データの住所に都道府県が含まれている場合は手動で修正が必要

## テスト

- [x] 管理画面でブルワリーの住所を編集できる
- [x] 詳細ページで都道府県+住所が正しく表示される
- [x] 都道府県のみ、住所のみの場合も正しく表示される
