### PR TITLE
issue/58 ブルワリーの画像参照元URL機能を追加

### DIFF
--- a/src/app/admin/breweries/BreweryForm.tsx
+++ b/src/app/admin/breweries/BreweryForm.tsx
@@ -16,6 +16,7 @@ interface Brewery {
   address: string | null;
   websiteUrl: string | null;
   imageUrl: string | null;
+  imageSourceUrl: string | null;
   status: string;
 }
 
@@ -44,6 +45,9 @@ export function BreweryForm({ brewery, prefectures }: Props) {
   const [imageUrl, setImageUrl] = useState<string | null>(
     brewery?.imageUrl || null
   );
+  const [imageSourceUrl, setImageSourceUrl] = useState(
+    brewery?.imageSourceUrl || ""
+  );
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -63,6 +67,7 @@ export function BreweryForm({ brewery, prefectures }: Props) {
         address: address || null,
         websiteUrl: websiteUrl || null,
         imageUrl,
+        imageSourceUrl: imageSourceUrl || null,
       };
 
       const result = isEdit
@@ -207,12 +212,32 @@ export function BreweryForm({ brewery, prefectures }: Props) {
       <fieldset className="fieldset bg-base-200 border-base-300 rounded-box border p-4">
         <legend className="fieldset-legend">画像</legend>
 
-        <ImageUploader
-          category="breweries"
-          onUploadComplete={(url) => setImageUrl(url || null)}
-          currentImageUrl={imageUrl}
-          aspectRatio="square"
-        />
+        <div className="space-y-4">
+          <ImageUploader
+            category="breweries"
+            onUploadComplete={(url) => setImageUrl(url || null)}
+            currentImageUrl={imageUrl}
+            aspectRatio="square"
+          />
+
+          {/* 画像参照元URL */}
+          <div>
+            <label htmlFor="brewery-image-source" className="label">
+              <span className="text-base label-text">画像参照元URL</span>
+            </label>
+            <input
+              id="brewery-image-source"
+              type="url"
+              value={imageSourceUrl}
+              onChange={(e) => setImageSourceUrl(e.target.value)}
+              className="w-full input input-bordered"
+              placeholder="https://..."
+            />
+            <p className="text-sm text-base-content/60 mt-1">
+              外部サイトから画像を使用する場合、出典元のURLを入力してください
+            </p>
+          </div>
+        </div>
       </fieldset>
 
       {/* ボタン */}

--- a/src/app/admin/breweries/[id]/edit/page.tsx
+++ b/src/app/admin/breweries/[id]/edit/page.tsx
@@ -30,6 +30,7 @@ export default async function EditBreweryPage({ params }: Props) {
       address: breweries.address,
       websiteUrl: breweries.websiteUrl,
       imageUrl: breweries.imageUrl,
+      imageSourceUrl: breweries.imageSourceUrl,
       status: breweries.status,
     })
     .from(breweries)

--- a/src/app/admin/breweries/actions.ts
+++ b/src/app/admin/breweries/actions.ts
@@ -32,6 +32,7 @@ interface BreweryInput {
   address: string | null;
   websiteUrl: string | null;
   imageUrl: string | null;
+  imageSourceUrl: string | null;
 }
 
 // ブルワリーの作成
@@ -60,6 +61,7 @@ export async function createBrewery(input: BreweryInput) {
       address: input.address,
       websiteUrl: input.websiteUrl,
       imageUrl: input.imageUrl,
+      imageSourceUrl: input.imageSourceUrl,
       status: "approved",
     });
 
@@ -100,6 +102,7 @@ export async function updateBrewery(breweryId: number, input: BreweryInput) {
         address: input.address,
         websiteUrl: input.websiteUrl,
         imageUrl: input.imageUrl,
+        imageSourceUrl: input.imageSourceUrl,
         updatedAt: new Date(),
       })
       .where(eq(breweries.id, breweryId));

--- a/src/app/breweries/[id]/page.tsx
+++ b/src/app/breweries/[id]/page.tsx
@@ -80,6 +80,7 @@ export default async function BreweryDetailPage({ params }: Props) {
       address: breweries.address,
       websiteUrl: breweries.websiteUrl,
       imageUrl: breweries.imageUrl,
+      imageSourceUrl: breweries.imageSourceUrl,
       prefecture: {
         id: prefectures.id,
         name: prefectures.name,
@@ -157,6 +158,19 @@ export default async function BreweryDetailPage({ params }: Props) {
                 />
               </svg>
             </div>
+          )}
+          {brewery.imageSourceUrl && (
+            <p className="text-sm text-base-content/60 mt-2 text-center">
+              画像出典元:{" "}
+              <a
+                href={brewery.imageSourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="link link-hover"
+              >
+                {new URL(brewery.imageSourceUrl).hostname}
+              </a>
+            </p>
           )}
         </div>
 

--- a/src/lib/db/schema/breweries.ts
+++ b/src/lib/db/schema/breweries.ts
@@ -10,6 +10,7 @@ export const breweries = pgTable("breweries", {
   address: text("address"),
   websiteUrl: text("website_url"),
   imageUrl: text("image_url"),
+  imageSourceUrl: text("image_source_url"), // 画像の参照元URL
   status: text("status").default("approved").notNull(), // 'pending' | 'approved' | 'rejected'
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),


### PR DESCRIPTION
## 概要

ブルワリーの画像に参照元URLを設定できる機能を追加。
外部サイト（ブルワリーのホームページなど）から画像を使用する際に、出典を明示できるようにした。

Closes #58

## 変更内容

- `breweries` テーブルに `image_source_url` カラムを追加
- 管理画面のブルワリー編集フォームに「画像参照元URL」入力フィールドを追加
- ブルワリー詳細ページで画像の下に出典元リンクを表示（ドメイン名を表示）

## 確認事項

- [x] スキーマ変更を `drizzle-kit push` で反映済み
- [x] 管理画面でブルワリーの画像参照元URLを設定できる
- [x] ブルワリー詳細ページで出典元が表示される

## テスト

- [x] 新規ブルワリー作成時に画像参照元URLを設定
- [x] 既存ブルワリー編集時に画像参照元URLを追加・変更
- [x] 詳細ページで「画像出典元: ドメイン名」がリンクとして表示される
- [x] 画像参照元URLが未設定の場合、出典表示がされないことを確認
