### PR TITLE
issue/73 remember_tokensのRLS問題を修正

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -3,6 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import {
   validateRememberTokenFromRequest,
   createSupabaseSessionForUser,
+  rotateRememberTokenForMiddleware,
   REMEMBER_TOKEN_COOKIE_NAME,
 } from "@/lib/auth/remember-me";
 
@@ -55,6 +56,11 @@ export async function updateSession(request: NextRequest) {
 
         if (!error && data.user) {
           user = data.user;
+          // トークンをローテーション（有効期限を延長）
+          await rotateRememberTokenForMiddleware(
+            rememberUser.userId,
+            supabaseResponse
+          );
         }
       } else {
         // セッション発行に失敗した場合、無効なトークンとしてCookieを削除


### PR DESCRIPTION
## 概要

Remember me機能（自動ログイン）がstaging環境で動作しない問題を修正。

Closes #73

## 変更内容

### 問題の原因
ミドルウェアはEdge Runtimeで実行されるが、Drizzle ORM（postgres.js）はNode.jsの`net`モジュールを使用しており、Edge Runtimeでは利用できなかった。


### 修正内容
- **`validateRememberTokenFromRequest`をSupabase Clientに変更**: Edge Runtime対応のためHTTP経由でDBアクセス
- **トークンローテーション機能を追加**: 自動ログイン成功時にトークンを再発行し、有効期限を30日延長

### 変更ファイル
- `src/lib/auth/remember-me.ts`: ミドルウェア用関数をSupabase Client使用に変更、`rotateRememberTokenForMiddleware`追加
- `src/lib/supabase/middleware.ts`: トークンローテーション呼び出しを追加

## 確認事項

- [x] Edge Runtimeでのエラーが解消されること
- [x] 自動ログインが正常に動作すること
- [x] トークンローテーションで有効期限が延長されること

## テスト

- [x] staging環境でremember_tokenを持った状態でアクセスし、エラーが出ないことを確認
- [x] 自動ログイン後、Cookieの`remember_token`が更新されていることを確認
