### PR TITLE
Issue/81 ビアスタイルのURL構造をslugベースからidベースに変更し、slugカラムを削除

### DIFF
--- a/src/app/admin/requests/actions.ts
+++ b/src/app/admin/requests/actions.ts
@@ -132,17 +132,9 @@ export async function approveStyle(requestId: number) {
       return { success: false, error: "申請が見つかりません" };
     }
 
-    // スラグを生成（名前からURLフレンドリーな文字列に）
-    const slug = request.name
-      .toLowerCase()
-      .replace(/[^a-z0-9\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]/g, "-")
-      .replace(/-+/g, "-")
-      .replace(/^-|-$/g, "");
-
     // beerStylesテーブルに追加
     await db.insert(beerStyles).values({
       name: request.name,
-      slug: slug || `style-${requestId}`,
       description: request.description,
       status: "approved",
     });

--- a/src/app/admin/styles/StyleForm.tsx
+++ b/src/app/admin/styles/StyleForm.tsx
@@ -8,7 +8,6 @@ import { createStyle, updateStyle } from "./[id]/edit/actions";
 interface Style {
   id: number;
   name: string;
-  slug: string;
   description: string | null;
   shortDescription: string | null;
   bitterness: number | null;

--- a/src/app/admin/styles/StyleList.tsx
+++ b/src/app/admin/styles/StyleList.tsx
@@ -8,7 +8,6 @@ import { deleteStyle, updateStyleStatus } from "./actions";
 interface Style {
   id: number;
   name: string;
-  slug: string;
   description: string | null;
   status: string;
   createdAt: Date;

--- a/src/app/admin/styles/[id]/edit/actions.ts
+++ b/src/app/admin/styles/[id]/edit/actions.ts
@@ -90,13 +90,6 @@ export async function createStyle(input: StyleInput) {
   }
 
   try {
-    // スラグを生成
-    const slug = input.name
-      .toLowerCase()
-      .replace(/[^a-z0-9\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]/g, "-")
-      .replace(/-+/g, "-")
-      .replace(/^-|-$/g, "") || `style-${Date.now()}`;
-
     // 重複チェック
     const [existingStyle] = await db
       .select()
@@ -111,7 +104,6 @@ export async function createStyle(input: StyleInput) {
       .insert(beerStyles)
       .values({
         name: input.name,
-        slug,
         description: input.description,
         shortDescription: input.shortDescription,
         status: "approved",
@@ -160,18 +152,10 @@ export async function updateStyle(styleId: number, input: StyleInput) {
   }
 
   try {
-    // スラグを生成
-    const slug = input.name
-      .toLowerCase()
-      .replace(/[^a-z0-9\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]/g, "-")
-      .replace(/-+/g, "-")
-      .replace(/^-|-$/g, "") || `style-${styleId}`;
-
     await db
       .update(beerStyles)
       .set({
         name: input.name,
-        slug,
         description: input.description,
         shortDescription: input.shortDescription,
         bitterness: input.bitterness,
@@ -209,7 +193,7 @@ export async function updateStyle(styleId: number, input: StyleInput) {
 
     revalidatePath("/admin/styles");
     revalidatePath("/styles");
-    revalidatePath(`/styles/${slug}`);
+    revalidatePath(`/styles/${styleId}`);
     return { success: true };
   } catch (error) {
     console.error("Failed to update style:", error);

--- a/src/app/admin/styles/actions.ts
+++ b/src/app/admin/styles/actions.ts
@@ -90,18 +90,10 @@ export async function updateStyle(styleId: number, input: UpdateStyleInput) {
   }
 
   try {
-    // スラグを生成
-    const slug = input.name
-      .toLowerCase()
-      .replace(/[^a-z0-9\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]/g, "-")
-      .replace(/-+/g, "-")
-      .replace(/^-|-$/g, "") || `style-${styleId}`;
-
     await db
       .update(beerStyles)
       .set({
         name: input.name,
-        slug,
         description: input.description,
         status: input.status,
         updatedAt: new Date(),
@@ -124,7 +116,7 @@ export async function updateStyle(styleId: number, input: UpdateStyleInput) {
 
     revalidatePath("/admin/styles");
     revalidatePath("/styles");
-    revalidatePath(`/styles/${slug}`);
+    revalidatePath(`/styles/${styleId}`);
     return { success: true };
   } catch (error) {
     console.error("Failed to update style:", error);

--- a/src/app/beers/[id]/page.tsx
+++ b/src/app/beers/[id]/page.tsx
@@ -184,12 +184,11 @@ async function FilteredBeersPage({ filterType, filterId }: { filterType: "style"
   const isAuthenticated = !!user;
 
   let filterName = "";
-  let styleSlug: string | null = null;
 
   // フィルター対象の情報を取得
   if (filterType === "style") {
     const style = await db
-      .select({ id: beerStyles.id, name: beerStyles.name, slug: beerStyles.slug })
+      .select({ id: beerStyles.id, name: beerStyles.name })
       .from(beerStyles)
       .where(eq(beerStyles.id, filterId))
       .limit(1)
@@ -199,7 +198,6 @@ async function FilteredBeersPage({ filterType, filterId }: { filterType: "style"
       notFound();
     }
     filterName = style.name;
-    styleSlug = style.slug;
   } else {
     const brewery = await db
       .select({ id: breweries.id, name: breweries.name })
@@ -239,7 +237,6 @@ async function FilteredBeersPage({ filterType, filterId }: { filterType: "style"
       style: {
         id: beerStyles.id,
         name: beerStyles.name,
-        slug: beerStyles.slug,
       },
     })
     .from(beers)
@@ -286,8 +283,8 @@ async function FilteredBeersPage({ filterType, filterId }: { filterType: "style"
             ? `${filterName}スタイルのクラフトビールを探索しよう。`
             : `${filterName}が醸造するクラフトビールを探索しよう。`}
         </p>
-        {filterType === "style" && styleSlug && (
-          <Link href={`/styles/${styleSlug}`} className="btn btn-outline btn-sm">
+        {filterType === "style" && (
+          <Link href={`/styles/${filterId}`} className="btn btn-outline btn-sm">
             {filterName}について詳しく見る →
           </Link>
         )}
@@ -374,7 +371,6 @@ async function BeerDetailPage({ beerId }: { beerId: number }) {
       style: {
         id: beerStyles.id,
         name: beerStyles.name,
-        slug: beerStyles.slug,
         bitterness: beerStyles.bitterness,
         sweetness: beerStyles.sweetness,
         body: beerStyles.body,
@@ -550,7 +546,7 @@ async function BeerDetailPage({ beerId }: { beerId: number }) {
           <div className="flex flex-wrap gap-3 mt-6">
             {beer.style && (
               <Link
-                href={`/styles/${beer.style.slug}`}
+                href={`/styles/${beer.style.id}`}
                 className="badge badge-primary badge-lg hover:badge-primary/80"
               >
                 {beer.style.name}
@@ -663,7 +659,7 @@ async function BeerDetailPage({ beerId }: { beerId: number }) {
         <div className="flex flex-wrap gap-3">
           {beer.style?.id && (
             <Link
-              href={`/beers/style/${beer.style.slug}`}
+              href={`/beers/style/${beer.style.id}`}
               className="btn btn-outline btn-sm"
             >
               {beer.style.name}のビール一覧 →

--- a/src/app/beers/abv/[level]/page.tsx
+++ b/src/app/beers/abv/[level]/page.tsx
@@ -106,7 +106,6 @@ export default async function AbvBeerPage({ params, searchParams }: Props) {
       style: {
         id: beerStyles.id,
         name: beerStyles.name,
-        slug: beerStyles.slug,
       },
     })
     .from(beers)
@@ -124,7 +123,6 @@ export default async function AbvBeerPage({ params, searchParams }: Props) {
         .selectDistinct({
           id: beerStyles.id,
           name: beerStyles.name,
-          slug: beerStyles.slug,
         })
         .from(beerStyles)
         .innerJoin(beers, eq(beers.styleId, beerStyles.id))

--- a/src/app/beers/bitterness/[level]/page.tsx
+++ b/src/app/beers/bitterness/[level]/page.tsx
@@ -109,7 +109,6 @@ export default async function BitternessBeerPage({
       style: {
         id: beerStyles.id,
         name: beerStyles.name,
-        slug: beerStyles.slug,
       },
     })
     .from(beers)
@@ -127,7 +126,6 @@ export default async function BitternessBeerPage({
         .selectDistinct({
           id: beerStyles.id,
           name: beerStyles.name,
-          slug: beerStyles.slug,
         })
         .from(beerStyles)
         .innerJoin(beers, eq(beers.styleId, beerStyles.id))

--- a/src/app/beers/brewery/[id]/page.tsx
+++ b/src/app/beers/brewery/[id]/page.tsx
@@ -125,7 +125,6 @@ export default async function BreweryBeersPage({
       style: {
         id: beerStyles.id,
         name: beerStyles.name,
-        slug: beerStyles.slug,
       },
     })
     .from(beers)
@@ -141,7 +140,7 @@ export default async function BreweryBeersPage({
     await Promise.all([
       // ビールが存在するスタイルのみ取得
       db
-        .selectDistinct({ id: beerStyles.id, name: beerStyles.name, slug: beerStyles.slug })
+        .selectDistinct({ id: beerStyles.id, name: beerStyles.name })
         .from(beerStyles)
         .innerJoin(beers, eq(beers.styleId, beerStyles.id))
         .where(eq(beerStyles.status, "approved"))

--- a/src/app/beers/page.tsx
+++ b/src/app/beers/page.tsx
@@ -49,7 +49,7 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
   if (activeFilters === 1 && !q) {
     if (style) {
       const styleData = await db
-        .select({ slug: beerStyles.slug, name: beerStyles.name })
+        .select({ name: beerStyles.name })
         .from(beerStyles)
         .where(eq(beerStyles.id, parseInt(style, 10)))
         .limit(1)
@@ -60,7 +60,7 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
           title: `${styleData.name}のビール一覧`,
           description: `${styleData.name}スタイルのクラフトビールを探索。Beer Linkで${styleData.name}のビールを見つけよう。`,
           alternates: {
-            canonical: `${siteUrl}/beers/style/${styleData.slug}`,
+            canonical: `${siteUrl}/beers/style/${style}`,
           },
         };
       }
@@ -223,7 +223,6 @@ export default async function BeersPage({ searchParams }: Props) {
       style: {
         id: beerStyles.id,
         name: beerStyles.name,
-        slug: beerStyles.slug,
       },
     })
     .from(beers)
@@ -239,7 +238,7 @@ export default async function BeersPage({ searchParams }: Props) {
     await Promise.all([
       // ビールが存在するスタイルのみ取得
       db
-        .selectDistinct({ id: beerStyles.id, name: beerStyles.name, slug: beerStyles.slug })
+        .selectDistinct({ id: beerStyles.id, name: beerStyles.name })
         .from(beerStyles)
         .innerJoin(beers, eq(beers.styleId, beerStyles.id))
         .where(eq(beerStyles.status, "approved"))

--- a/src/app/beers/prefecture/[id]/page.tsx
+++ b/src/app/beers/prefecture/[id]/page.tsx
@@ -126,7 +126,6 @@ export default async function PrefectureBeersPage({
       style: {
         id: beerStyles.id,
         name: beerStyles.name,
-        slug: beerStyles.slug,
       },
     })
     .from(beers)
@@ -142,7 +141,7 @@ export default async function PrefectureBeersPage({
     await Promise.all([
       // ビールが存在するスタイルのみ取得
       db
-        .selectDistinct({ id: beerStyles.id, name: beerStyles.name, slug: beerStyles.slug })
+        .selectDistinct({ id: beerStyles.id, name: beerStyles.name })
         .from(beerStyles)
         .innerJoin(beers, eq(beers.styleId, beerStyles.id))
         .where(eq(beerStyles.status, "approved"))

--- a/src/app/breweries/[id]/page.tsx
+++ b/src/app/breweries/[id]/page.tsx
@@ -112,7 +112,6 @@ export default async function BreweryDetailPage({ params }: Props) {
       style: {
         id: beerStyles.id,
         name: beerStyles.name,
-        slug: beerStyles.slug,
       },
     })
     .from(beers)

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -95,7 +95,6 @@ export default async function MyPage() {
       style: {
         id: beerStyles.id,
         name: beerStyles.name,
-        slug: beerStyles.slug,
       },
     })
     .from(beerFavorites)

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -88,7 +88,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       .select({ id: breweries.id, updatedAt: breweries.updatedAt, prefectureId: breweries.prefectureId })
       .from(breweries),
     db
-      .select({ id: beerStyles.id, slug: beerStyles.slug, updatedAt: beerStyles.updatedAt })
+      .select({ id: beerStyles.id, updatedAt: beerStyles.updatedAt })
       .from(beerStyles),
     db
       .selectDistinct({ id: prefectures.id })
@@ -123,7 +123,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // ビアスタイル詳細ページ
   const stylePages: MetadataRoute.Sitemap = styleList.map((style) => ({
-    url: `${siteUrl}/styles/${style.slug}`,
+    url: `${siteUrl}/styles/${style.id}`,
     lastModified: style.updatedAt || new Date(),
     changeFrequency: "monthly" as const,
     priority: 0.6,
@@ -131,7 +131,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // ビアスタイル別ビール一覧ページ
   const styleBeerPages: MetadataRoute.Sitemap = styleList.map((style) => ({
-    url: `${siteUrl}/beers/style/${style.slug}`,
+    url: `${siteUrl}/beers/style/${style.id}`,
     lastModified: new Date(),
     changeFrequency: "daily" as const,
     priority: 0.7,

--- a/src/app/submit/style/actions.ts
+++ b/src/app/submit/style/actions.ts
@@ -53,17 +53,9 @@ export async function submitStyle(input: SubmitStyleInput) {
     return { success: false, error: "この名前は既に別のスタイルの別名として登録されています" };
   }
 
-  // スラグを生成
-  const slug = input.name
-    .toLowerCase()
-    .replace(/[^a-z0-9\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "") || `style-${Date.now()}`;
-
   try {
     await db.insert(beerStyles).values({
       name: input.name,
-      slug,
       status: "pending", // 管理者の確認待ち
     });
 

--- a/src/components/beer/BeerCard.tsx
+++ b/src/components/beer/BeerCard.tsx
@@ -17,7 +17,6 @@ interface BeerCardProps {
     style?: {
       id: number;
       name: string;
-      slug: string;
     } | null;
   };
 }

--- a/src/components/beer/BeerFilter.tsx
+++ b/src/components/beer/BeerFilter.tsx
@@ -17,7 +17,6 @@ interface FilterOption {
 }
 
 interface StyleOption extends FilterOption {
-  slug?: string;
   otherNames?: string[];
 }
 
@@ -253,11 +252,8 @@ export function BeerFilter({
 
       if (activeFilters === 1 && !newQuery) {
         if (newStyle) {
-          const style = styles.find((s) => String(s.id) === newStyle);
-          if (style?.slug) {
-            router.push(`/beers/style/${style.slug}`);
-            return;
-          }
+          router.push(`/beers/style/${newStyle}`);
+          return;
         }
         if (newBrewery) {
           router.push(`/beers/brewery/${newBrewery}`);
@@ -288,7 +284,7 @@ export function BeerFilter({
       const queryString = params.toString();
       router.push(queryString ? `/beers?${queryString}` : "/beers");
     },
-    [router, styles]
+    [router]
   );
 
   const handleStyleChange = useCallback(

--- a/src/components/beer/RelatedStyles.tsx
+++ b/src/components/beer/RelatedStyles.tsx
@@ -2,9 +2,9 @@ import Link from "next/link";
 import type { BeerStyle } from "@/lib/db/schema";
 
 interface RelatedStylesProps {
-  parentStyles: Pick<BeerStyle, "id" | "slug" | "name">[];
-  childStyles: Pick<BeerStyle, "id" | "slug" | "name">[];
-  siblingStyles: Pick<BeerStyle, "id" | "slug" | "name">[];
+  parentStyles: Pick<BeerStyle, "id" | "name">[];
+  childStyles: Pick<BeerStyle, "id" | "name">[];
+  siblingStyles: Pick<BeerStyle, "id" | "name">[];
 }
 
 export function RelatedStyles({
@@ -51,7 +51,7 @@ export function RelatedStyles({
                 {parentStyles.map((style) => (
                   <li key={style.id}>
                     <Link
-                      href={`/styles/${style.slug}`}
+                      href={`/styles/${style.id}`}
                       className="link link-hover text-primary flex items-center gap-1"
                     >
                       <span className="text-sm">→</span>
@@ -87,7 +87,7 @@ export function RelatedStyles({
                 {childStyles.map((style) => (
                   <li key={style.id}>
                     <Link
-                      href={`/styles/${style.slug}`}
+                      href={`/styles/${style.id}`}
                       className="link link-hover text-primary flex items-center gap-1"
                     >
                       <span className="text-sm">→</span>
@@ -123,7 +123,7 @@ export function RelatedStyles({
                 {siblingStyles.map((style) => (
                   <li key={style.id}>
                     <Link
-                      href={`/styles/${style.slug}`}
+                      href={`/styles/${style.id}`}
                       className="link link-hover text-primary flex items-center gap-1"
                     >
                       <span className="text-sm">→</span>

--- a/src/components/beer/StyleCard.tsx
+++ b/src/components/beer/StyleCard.tsx
@@ -36,7 +36,7 @@ export function StyleCard({ style }: StyleCardProps) {
   const textColor = getSrmTextColor(style.srmMin, style.srmMax);
 
   return (
-    <Link href={`/styles/${style.slug}`}>
+    <Link href={`/styles/${style.id}`}>
       <div className="card bg-base-100 shadow-md hover:shadow-lg transition-shadow cursor-pointer h-full overflow-hidden">
         {/* SRM色のヘッダー */}
         <div

--- a/src/lib/db/schema/beer-styles.ts
+++ b/src/lib/db/schema/beer-styles.ts
@@ -3,7 +3,6 @@ import { relations } from "drizzle-orm";
 
 export const beerStyles = pgTable("beer_styles", {
   id: serial("id").primaryKey(),
-  slug: text("slug").notNull().unique(),
   name: text("name").notNull().unique(),
   shortDescription: varchar("short_description", { length: 100 }), // 一覧ページ用の短い紹介文
   description: text("description"),

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -107,7 +107,6 @@ async function seed() {
   // 3. ビアスタイルデータを投入
   console.log("🍺 Inserting beer styles...");
   const styleValues = styleRows.map((row) => ({
-    slug: row.slug || "",
     name: row.name || "",
     description: row.description || null,
     bitterness: row.bitterness ? parseInt(row.bitterness) : null,


### PR DESCRIPTION
## 概要

ビアスタイルのURL構造をslugベースからidベースに変更し、slugカラムを削除しました。

Closes #81

## 変更内容

- `/styles/[slug]` → `/styles/[id]` に変更
- `/beers/style/[slug]` → `/beers/style/[id]` に変更
- スキーマ（beer-styles.ts）からslugカラムを削除
- 管理画面のslug生成ロジックを削除
- 全ページ・コンポーネントのスタイルリンクをidベースに更新
- sitemapのURL生成をidベースに更新

## 確認事項

- [x] `/styles/{id}` でスタイル詳細ページが表示される
- [x] `/beers/style/{id}` でスタイル別ビール一覧が表示される
- [x] フィルターでスタイル選択時に正しいURLに遷移する
- [x] 管理画面でスタイルの作成・編集ができる
- [x] sitemapが正しく生成される

## テスト

- [x] `npx drizzle-kit push` でDBからslugカラムを削除
- [x] 各スタイルページへのリンクが正しく動作する
- [x] 存在しないidでアクセスした場合に404が表示される
