### PR TITLE
issue/84 sitemap の修正

### DIFF
--- a/src/app/beers/[id]/page.tsx
+++ b/src/app/beers/[id]/page.tsx
@@ -250,7 +250,6 @@ async function FilteredBeersPage({ filterType, filterId }: { filterType: "style"
     db
       .select({ id: beerStyles.id, name: beerStyles.name })
       .from(beerStyles)
-      .where(eq(beerStyles.status, "approved"))
       .orderBy(beerStyles.name),
     db
       .select({ id: breweries.id, name: breweries.name })

--- a/src/app/beers/abv/[level]/page.tsx
+++ b/src/app/beers/abv/[level]/page.tsx
@@ -126,7 +126,6 @@ export default async function AbvBeerPage({ params, searchParams }: Props) {
         })
         .from(beerStyles)
         .innerJoin(beers, eq(beers.styleId, beerStyles.id))
-        .where(eq(beerStyles.status, "approved"))
         .orderBy(beerStyles.name),
       db
         .select({

--- a/src/app/beers/bitterness/[level]/page.tsx
+++ b/src/app/beers/bitterness/[level]/page.tsx
@@ -129,7 +129,6 @@ export default async function BitternessBeerPage({
         })
         .from(beerStyles)
         .innerJoin(beers, eq(beers.styleId, beerStyles.id))
-        .where(eq(beerStyles.status, "approved"))
         .orderBy(beerStyles.name),
       db
         .select({

--- a/src/app/beers/brewery/[id]/page.tsx
+++ b/src/app/beers/brewery/[id]/page.tsx
@@ -143,7 +143,6 @@ export default async function BreweryBeersPage({
         .selectDistinct({ id: beerStyles.id, name: beerStyles.name })
         .from(beerStyles)
         .innerJoin(beers, eq(beers.styleId, beerStyles.id))
-        .where(eq(beerStyles.status, "approved"))
         .orderBy(beerStyles.name),
       db
         .select({

--- a/src/app/beers/page.tsx
+++ b/src/app/beers/page.tsx
@@ -241,7 +241,6 @@ export default async function BeersPage({ searchParams }: Props) {
         .selectDistinct({ id: beerStyles.id, name: beerStyles.name })
         .from(beerStyles)
         .innerJoin(beers, eq(beers.styleId, beerStyles.id))
-        .where(eq(beerStyles.status, "approved"))
         .orderBy(beerStyles.name),
       db
         .select({

--- a/src/app/beers/prefecture/[id]/page.tsx
+++ b/src/app/beers/prefecture/[id]/page.tsx
@@ -144,7 +144,6 @@ export default async function PrefectureBeersPage({
         .selectDistinct({ id: beerStyles.id, name: beerStyles.name })
         .from(beerStyles)
         .innerJoin(beers, eq(beers.styleId, beerStyles.id))
-        .where(eq(beerStyles.status, "approved"))
         .orderBy(beerStyles.name),
       db
         .select({

--- a/src/app/beers/style/[id]/page.tsx
+++ b/src/app/beers/style/[id]/page.tsx
@@ -140,7 +140,6 @@ export default async function StyleBeersPage({ params, searchParams }: Props) {
         .selectDistinct({ id: beerStyles.id, name: beerStyles.name })
         .from(beerStyles)
         .innerJoin(beers, eq(beers.styleId, beerStyles.id))
-        .where(eq(beerStyles.status, "approved"))
         .orderBy(beerStyles.name),
       db
         .select({

--- a/src/app/styles/page.tsx
+++ b/src/app/styles/page.tsx
@@ -109,7 +109,7 @@ export default async function StylesPage({ searchParams }: Props) {
   const offset = (currentPage - 1) * ITEMS_PER_PAGE;
 
   // 検索条件を構築
-  const conditions: SQL[] = [eq(beerStyles.status, "approved")];
+  const conditions: SQL[] = [];
 
   // 範囲フィルター用のヘルパー
   const addRangeCondition = (

--- a/src/app/submit/beer/page.tsx
+++ b/src/app/submit/beer/page.tsx
@@ -1,6 +1,5 @@
 import { db } from "@/lib/db";
 import { breweries, beerStyles, beerStyleOtherNames } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { BeerSubmitForm } from "./BeerSubmitForm";
@@ -30,11 +29,10 @@ export default async function BeerSubmitPage() {
     .from(breweries)
     .orderBy(breweries.name);
 
-  // ビアスタイル一覧を取得（承認済みのみ）
+  // ビアスタイル一覧を取得
   const styleList = await db
     .select({ id: beerStyles.id, name: beerStyles.name })
     .from(beerStyles)
-    .where(eq(beerStyles.status, "approved"))
     .orderBy(beerStyles.name);
 
   // ビアスタイル別名一覧を取得


### PR DESCRIPTION
## 概要

サイトマップの品質向上とビアスタイルの`status`フィルタリング修正

Closes #84

## 変更内容

### サイトマップの改善
- `/beers/style/${id}` ページ: ビールが存在するスタイルのみをサイトマップに含めるよう修正
- `/beers/brewery/${id}` ページ: ビールが存在するブルワリーのみをサイトマップに含めるよう修正
- これにより検索結果が0件になるページがサイトマップに含まれなくなる

### ビアスタイルのstatusフィルタ削除
- フロントエンドページから`beerStyles.status`のフィルタリングを削除
- `status`フィールドは管理画面でのトラッキング用途のみに変更
- ユーザーがスタイルを追加したら、管理者の確認を待たずにすぐに使えるようになる

## 対象ファイル
- `src/app/sitemap.ts` - サイトマップ生成ロジックの改善
- `src/app/beers/page.tsx` - statusフィルタ削除
- `src/app/beers/[id]/page.tsx` - statusフィルタ削除
- `src/app/beers/style/[id]/page.tsx` - statusフィルタ削除
- `src/app/beers/abv/[level]/page.tsx` - statusフィルタ削除
- `src/app/beers/bitterness/[level]/page.tsx` - statusフィルタ削除
- `src/app/beers/brewery/[id]/page.tsx` - statusフィルタ削除
- `src/app/beers/prefecture/[id]/page.tsx` - statusフィルタ削除
- `src/app/styles/page.tsx` - statusフィルタ削除
- `src/app/submit/beer/page.tsx` - statusフィルタ削除、未使用import削除

## 確認事項

- [x] ビルドが成功する
- [x] サイトマップに0件ページが含まれていないことを確認
- [x] ユーザー追加スタイルがフロントエンドで即座に表示されることを確認
