### PR TITLE
Issue/80

### DIFF
--- a/seeds/sql/add-other-style.sql
+++ b/seeds/sql/add-other-style.sql
@@ -1,0 +1,6 @@
+-- 「その他」スタイルを追加
+-- 分類が難しいスタイルや新しいスタイルのビールに使用
+
+INSERT INTO beer_styles (name, description, status)
+VALUES ('その他', '分類が難しいスタイルや、新しいスタイルのビールはこちらを選択してください。', 'approved')
+ON CONFLICT (name) DO NOTHING;

--- a/src/app/admin/beers/BeerForm.tsx
+++ b/src/app/admin/beers/BeerForm.tsx
@@ -6,12 +6,14 @@ import Link from "next/link";
 import { ImageUploader } from "@/components/ui/ImageUploader";
 import { FormSearchSelect } from "@/components/ui/FormSearchSelect";
 import { createBeer, updateBeer } from "./actions";
+import { OTHER_STYLE_NAME } from "@/lib/constants/beer-styles";
 
 interface Beer {
   id: number;
   name: string;
   breweryId: number | null;
   styleId: number | null;
+  customStyleText: string | null;
   abv: string | null;
   ibu: number | null;
   shortDescription: string | null;
@@ -38,7 +40,14 @@ export function BeerForm({ beer, breweries, styles }: Props) {
     beer?.breweryId || null
   );
   const [styleId, setStyleId] = useState<number | null>(beer?.styleId || null);
+  const [customStyleText, setCustomStyleText] = useState(
+    beer?.customStyleText || ""
+  );
   const [abv, setAbv] = useState(beer?.abv || "");
+
+  // 「その他」スタイルが選択されているか判定
+  const isOtherStyleSelected =
+    styleId !== null && styles.find((s) => s.id === styleId)?.name === OTHER_STYLE_NAME;
   const [ibu, setIbu] = useState(beer?.ibu?.toString() || "");
   const [shortDescription, setShortDescription] = useState(
     beer?.shortDescription || ""
@@ -68,6 +77,7 @@ export function BeerForm({ beer, breweries, styles }: Props) {
         name: name.trim(),
         breweryId,
         styleId,
+        customStyleText: isOtherStyleSelected ? customStyleText.trim() || null : null,
         abv: abv || null,
         ibu: ibu ? parseInt(ibu) : null,
         shortDescription: shortDescription || null,
@@ -133,6 +143,7 @@ export function BeerForm({ beer, breweries, styles }: Props) {
               }
               label="ブルワリー *"
               placeholder="ブルワリーを検索..."
+              maxResults={100}
             />
           </div>
 
@@ -142,14 +153,41 @@ export function BeerForm({ beer, breweries, styles }: Props) {
               id="beer-style"
               options={styles}
               value={styleId?.toString() || ""}
-              onChange={(value) =>
-                setStyleId(value ? parseInt(value, 10) : null)
-              }
+              onChange={(value) => {
+                const newStyleId = value ? parseInt(value, 10) : null;
+                setStyleId(newStyleId);
+                // スタイル変更時にカスタムテキストをクリア（「その他」以外の場合）
+                if (newStyleId === null || styles.find((s) => s.id === newStyleId)?.name !== OTHER_STYLE_NAME) {
+                  setCustomStyleText("");
+                }
+              }}
               label="スタイル"
               placeholder="スタイルを検索..."
               clearable
+              maxResults={100}
             />
           </div>
+
+          {/* その他選択時のカスタムスタイル入力 */}
+          {isOtherStyleSelected && (
+            <div>
+              <label htmlFor="beer-custom-style" className="label">
+                <span className="text-base label-text">スタイル名（任意）</span>
+              </label>
+              <input
+                id="beer-custom-style"
+                type="text"
+                value={customStyleText}
+                onChange={(e) => setCustomStyleText(e.target.value)}
+                className="w-full input input-bordered"
+                maxLength={100}
+                placeholder="例：フルーツサワーエール、スモークドラガー"
+              />
+              <p className="text-sm text-base-content/60 mt-1">
+                分類が難しいスタイルの場合は入力してください
+              </p>
+            </div>
+          )}
 
           {/* ABV */}
           <div>

--- a/src/app/admin/beers/[id]/edit/page.tsx
+++ b/src/app/admin/beers/[id]/edit/page.tsx
@@ -26,6 +26,7 @@ export default async function EditBeerPage({ params }: Props) {
       name: beers.name,
       breweryId: beers.breweryId,
       styleId: beers.styleId,
+      customStyleText: beers.customStyleText,
       abv: beers.abv,
       ibu: beers.ibu,
       shortDescription: beers.shortDescription,

--- a/src/app/admin/beers/actions.ts
+++ b/src/app/admin/beers/actions.ts
@@ -28,6 +28,7 @@ interface BeerInput {
   name: string;
   breweryId: number;
   styleId: number | null;
+  customStyleText?: string | null;
   abv: string | null;
   ibu: number | null;
   shortDescription: string | null;
@@ -57,6 +58,7 @@ export async function createBeer(input: BeerInput) {
       name: input.name,
       breweryId: input.breweryId,
       styleId: input.styleId,
+      customStyleText: input.customStyleText || null,
       abv: input.abv,
       ibu: input.ibu,
       shortDescription: input.shortDescription,
@@ -98,6 +100,7 @@ export async function updateBeer(beerId: number, input: BeerInput) {
         name: input.name,
         breweryId: input.breweryId,
         styleId: input.styleId,
+        customStyleText: input.customStyleText || null,
         abv: input.abv,
         ibu: input.ibu,
         shortDescription: input.shortDescription,

--- a/src/app/admin/breweries/BreweryForm.tsx
+++ b/src/app/admin/breweries/BreweryForm.tsx
@@ -130,6 +130,7 @@ export function BreweryForm({ brewery, prefectures }: Props) {
               label="都道府県"
               placeholder="都道府県を検索..."
               clearable
+              maxResults={50}
             />
           </div>
 

--- a/src/app/beers/[id]/page.tsx
+++ b/src/app/beers/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
   ABV_OPTIONS,
   ABV_RANGES,
 } from "@/lib/constants/beer-filters";
+import { OTHER_STYLE_NAME } from "@/lib/constants/beer-styles";
 import { ReviewCard } from "@/components/review/ReviewCard";
 import { AuthRequiredLink } from "@/components/ui/AuthRequiredLink";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
@@ -359,6 +360,7 @@ async function BeerDetailPage({ beerId }: { beerId: number }) {
       abv: beers.abv,
       ibu: beers.ibu,
       imageUrl: beers.imageUrl,
+      customStyleText: beers.customStyleText,
       brewery: {
         id: breweries.id,
         name: breweries.name,
@@ -544,12 +546,18 @@ async function BeerDetailPage({ beerId }: { beerId: number }) {
           {/* スペック */}
           <div className="flex flex-wrap gap-3 mt-6">
             {beer.style && (
-              <Link
-                href={`/styles/${beer.style.id}`}
-                className="badge badge-primary badge-lg hover:badge-primary/80"
-              >
-                {beer.style.name}
-              </Link>
+              beer.style.name === OTHER_STYLE_NAME ? (
+                <span className="badge badge-primary badge-lg">
+                  {beer.customStyleText || "その他"}
+                </span>
+              ) : (
+                <Link
+                  href={`/styles/${beer.style.id}`}
+                  className="badge badge-primary badge-lg hover:badge-primary/80"
+                >
+                  {beer.style.name}
+                </Link>
+              )
             )}
             {beer.abv && (
               <span className="badge badge-outline badge-lg">
@@ -568,8 +576,8 @@ async function BeerDetailPage({ beerId }: { beerId: number }) {
 
       {/* 味の特性セクション */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
-        {/* スタイルの味特性 */}
-        {beer.style && (
+        {/* スタイルの味特性（「その他」の場合は表示しない） */}
+        {beer.style && beer.style.name !== OTHER_STYLE_NAME && (
           <div className="card bg-base-100 shadow">
             <div className="card-body items-center">
               <h2 className="card-title">
@@ -656,7 +664,7 @@ async function BeerDetailPage({ beerId }: { beerId: number }) {
       <div className="mt-12 pt-8 border-t border-base-300">
         <h2 className="text-xl font-bold mb-4">関連するビール一覧</h2>
         <div className="flex flex-wrap gap-3">
-          {beer.style?.id && (
+          {beer.style?.id && beer.style.name !== OTHER_STYLE_NAME && (
             <Link
               href={`/beers/style/${beer.style.id}`}
               className="btn btn-outline btn-sm"

--- a/src/app/beers/abv/[level]/page.tsx
+++ b/src/app/beers/abv/[level]/page.tsx
@@ -99,6 +99,7 @@ export default async function AbvBeerPage({ params, searchParams }: Props) {
       abv: beers.abv,
       ibu: beers.ibu,
       imageUrl: beers.imageUrl,
+      customStyleText: beers.customStyleText,
       brewery: {
         id: breweries.id,
         name: breweries.name,

--- a/src/app/beers/bitterness/[level]/page.tsx
+++ b/src/app/beers/bitterness/[level]/page.tsx
@@ -102,6 +102,7 @@ export default async function BitternessBeerPage({
       abv: beers.abv,
       ibu: beers.ibu,
       imageUrl: beers.imageUrl,
+      customStyleText: beers.customStyleText,
       brewery: {
         id: breweries.id,
         name: breweries.name,

--- a/src/app/beers/brewery/[id]/page.tsx
+++ b/src/app/beers/brewery/[id]/page.tsx
@@ -118,6 +118,7 @@ export default async function BreweryBeersPage({
       abv: beers.abv,
       ibu: beers.ibu,
       imageUrl: beers.imageUrl,
+      customStyleText: beers.customStyleText,
       brewery: {
         id: breweries.id,
         name: breweries.name,

--- a/src/app/beers/page.tsx
+++ b/src/app/beers/page.tsx
@@ -216,6 +216,7 @@ export default async function BeersPage({ searchParams }: Props) {
       abv: beers.abv,
       ibu: beers.ibu,
       imageUrl: beers.imageUrl,
+      customStyleText: beers.customStyleText,
       brewery: {
         id: breweries.id,
         name: breweries.name,

--- a/src/app/beers/prefecture/[id]/page.tsx
+++ b/src/app/beers/prefecture/[id]/page.tsx
@@ -119,6 +119,7 @@ export default async function PrefectureBeersPage({
       abv: beers.abv,
       ibu: beers.ibu,
       imageUrl: beers.imageUrl,
+      customStyleText: beers.customStyleText,
       brewery: {
         id: breweries.id,
         name: breweries.name,

--- a/src/app/beers/style/[id]/page.tsx
+++ b/src/app/beers/style/[id]/page.tsx
@@ -115,6 +115,7 @@ export default async function StyleBeersPage({ params, searchParams }: Props) {
       abv: beers.abv,
       ibu: beers.ibu,
       imageUrl: beers.imageUrl,
+      customStyleText: beers.customStyleText,
       brewery: {
         id: breweries.id,
         name: breweries.name,

--- a/src/app/styles/[id]/page.tsx
+++ b/src/app/styles/[id]/page.tsx
@@ -12,6 +12,7 @@ import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { FlavorProfile, BeerCard, RelatedStyles } from "@/components/beer";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { OTHER_STYLE_NAME } from "@/lib/constants/beer-styles";
 import type { Metadata } from "next";
 
 // ビルド時にDBに接続できないため動的レンダリング
@@ -144,6 +145,11 @@ export default async function StylePage({ params }: Props) {
     .then((rows) => rows[0]);
 
   if (!style) {
+    notFound();
+  }
+
+  // 「その他」スタイルへのアクセスは許可しない
+  if (style.name === OTHER_STYLE_NAME) {
     notFound();
   }
 

--- a/src/app/styles/page.tsx
+++ b/src/app/styles/page.tsx
@@ -1,10 +1,11 @@
 import { db } from "@/lib/db";
 import { beerStyles, beerStyleOtherNames } from "@/lib/db/schema";
-import { eq, and, gte, lte, ilike, or, exists, count, type SQL, type Column } from "drizzle-orm";
+import { eq, and, gte, lte, ilike, or, exists, count, ne, type SQL, type Column } from "drizzle-orm";
 import { StyleCard } from "@/components/beer";
 import { StyleFilter } from "@/components/beer/StyleFilter";
 import { Pagination, ITEMS_PER_PAGE } from "@/components/ui/Pagination";
 import { Breadcrumb } from "@/components/ui/Breadcrumb";
+import { OTHER_STYLE_NAME } from "@/lib/constants/beer-styles";
 import type { Metadata } from "next";
 
 // ビルド時にDBに接続できないため動的レンダリング
@@ -110,6 +111,9 @@ export default async function StylesPage({ searchParams }: Props) {
 
   // 検索条件を構築
   const conditions: SQL[] = [];
+
+  // 「その他」スタイルを除外
+  conditions.push(ne(beerStyles.name, OTHER_STYLE_NAME));
 
   // 範囲フィルター用のヘルパー
   const addRangeCondition = (

--- a/src/app/submit/beer/BeerSubmitForm.tsx
+++ b/src/app/submit/beer/BeerSubmitForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { submitBeer } from "./actions";
 import { FormSearchSelect } from "@/components/ui/FormSearchSelect";
+import { OTHER_STYLE_NAME } from "@/lib/constants/beer-styles";
 
 interface BeerSubmitFormProps {
   breweries: { id: number; name: string }[];
@@ -20,6 +21,11 @@ export function BeerSubmitForm({ breweries, styles }: BeerSubmitFormProps) {
   const [name, setName] = useState("");
   const [breweryId, setBreweryId] = useState("");
   const [styleId, setStyleId] = useState("");
+  const [customStyleText, setCustomStyleText] = useState("");
+
+  // 「その他」スタイルが選択されているか判定
+  const isOtherStyleSelected =
+    styleId && styles.find((s) => s.id === parseInt(styleId, 10))?.name === OTHER_STYLE_NAME;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -40,6 +46,7 @@ export function BeerSubmitForm({ breweries, styles }: BeerSubmitFormProps) {
         name: name.trim(),
         breweryId: parseInt(breweryId, 10),
         styleId: styleId ? parseInt(styleId, 10) : null,
+        customStyleText: isOtherStyleSelected ? customStyleText.trim() || null : null,
       });
 
       if (result.success) {
@@ -65,6 +72,7 @@ export function BeerSubmitForm({ breweries, styles }: BeerSubmitFormProps) {
               setName("");
               setBreweryId("");
               setStyleId("");
+              setCustomStyleText("");
             }}
             className="btn btn-primary"
           >
@@ -110,6 +118,7 @@ export function BeerSubmitForm({ breweries, styles }: BeerSubmitFormProps) {
         label="ブルワリー"
         placeholder="ブルワリー名で検索..."
         required
+        maxResults={100}
         helperText={
           <>
             見つからない場合は{" "}
@@ -124,19 +133,48 @@ export function BeerSubmitForm({ breweries, styles }: BeerSubmitFormProps) {
       <FormSearchSelect
         options={styles}
         value={styleId}
-        onChange={setStyleId}
+        onChange={(value) => {
+          setStyleId(value);
+          // スタイル変更時にカスタムテキストをクリア
+          if (!value || styles.find((s) => s.id === parseInt(value, 10))?.name !== OTHER_STYLE_NAME) {
+            setCustomStyleText("");
+          }
+        }}
         label="ビアスタイル（任意）"
         placeholder="スタイル名で検索..."
         clearable
+        maxResults={100}
         helperText={
           <>
-            見つからない場合は{" "}
+            見つからない場合は「その他」を選択するか、
             <Link href="/submit/style" className="link link-primary">
               スタイルを追加
             </Link>
           </>
         }
       />
+
+      {/* その他選択時のカスタムスタイル入力 */}
+      {isOtherStyleSelected && (
+        <div className="form-control">
+          <label className="label">
+            <span className="label-text">スタイル名（任意）</span>
+          </label>
+          <input
+            type="text"
+            className="input input-bordered w-full"
+            placeholder="例：フルーツサワーエール、スモークドラガー"
+            value={customStyleText}
+            onChange={(e) => setCustomStyleText(e.target.value)}
+            maxLength={100}
+          />
+          <label className="label">
+            <span className="label-text-alt text-base-content/60">
+              分類が難しいスタイルの場合は入力してください
+            </span>
+          </label>
+        </div>
+      )}
 
       <button
         type="submit"

--- a/src/app/submit/beer/actions.ts
+++ b/src/app/submit/beer/actions.ts
@@ -11,6 +11,7 @@ interface SubmitBeerInput {
   name: string;
   breweryId: number;
   styleId: number | null;
+  customStyleText?: string | null;
 }
 
 export async function submitBeer(input: SubmitBeerInput) {
@@ -50,6 +51,7 @@ export async function submitBeer(input: SubmitBeerInput) {
       name: input.name,
       breweryId: input.breweryId,
       styleId: input.styleId,
+      customStyleText: input.customStyleText || null,
       status: "pending",
       submittedBy: user.id,
     });

--- a/src/components/beer/BeerCard.tsx
+++ b/src/components/beer/BeerCard.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
+import { OTHER_STYLE_NAME } from "@/lib/constants/beer-styles";
 
 interface BeerCardProps {
   beer: {
@@ -10,6 +11,7 @@ interface BeerCardProps {
     abv?: string | null;
     ibu?: number | null;
     imageUrl?: string | null;
+    customStyleText?: string | null;
     brewery?: {
       id: number;
       name: string;
@@ -68,7 +70,9 @@ export function BeerCard({ beer }: BeerCardProps) {
           <div className="flex flex-wrap gap-2 mt-2">
             {beer.style && (
               <span className="badge badge-primary badge-sm">
-                {beer.style.name}
+                {beer.style.name === OTHER_STYLE_NAME
+                  ? (beer.customStyleText || "その他")
+                  : beer.style.name}
               </span>
             )}
             {beer.abv && (

--- a/src/components/ui/FormSearchSelect.tsx
+++ b/src/components/ui/FormSearchSelect.tsx
@@ -176,7 +176,7 @@ export function FormSearchSelect({
 
       {helperText && (
         <label className="label">
-          <span className="label-text-alt">{helperText}</span>
+          <span className="label-text-alt whitespace-normal break-words">{helperText}</span>
         </label>
       )}
     </div>

--- a/src/lib/constants/beer-styles.ts
+++ b/src/lib/constants/beer-styles.ts
@@ -1,0 +1,2 @@
+// 「その他」スタイル名定数
+export const OTHER_STYLE_NAME = "その他";

--- a/src/lib/db/schema/beers.ts
+++ b/src/lib/db/schema/beers.ts
@@ -10,6 +10,7 @@ export const beers = pgTable("beers", {
   description: text("description"),
   breweryId: integer("brewery_id").notNull().references(() => breweries.id),
   styleId: integer("style_id").references(() => beerStyles.id),
+  customStyleText: varchar("custom_style_text", { length: 100 }), // 「その他」スタイル選択時のカスタム名
   abv: decimal("abv", { precision: 4, scale: 2 }),
   ibu: integer("ibu"),
   imageUrl: text("image_url"),


### PR DESCRIPTION
## 概要

ビールスタイルに「その他」オプションを追加し、既存のスタイル分類に当てはまらないビールを登録できるようにしました。

Closes #80

## 変更内容

### 新機能
- ビール追加・編集フォームで「その他」スタイル選択時にカスタムスタイル名を入力可能に
- ビール詳細ページ・一覧ページでカスタムスタイル名を表示

### 除外・制限
- スタイル一覧ページから「その他」を除外
- スタイル詳細ページへの「その他」アクセスは404
- サイトマップから「その他」スタイルを除外
- 「その他」スタイルのビールでは味特性（FlavorProfile）を非表示

### 改善
- FormSearchSelectの表示件数上限を10→100に拡大（ブルワリー・スタイル選択）
- helperTextの長文表示時の折り返し対応

## DB変更

```bash
# スキーマ反映
npx drizzle-kit push

# 「その他」スタイルを追加
psql -f seeds/sql/add-other-style.sql
```

## 確認事項

- [x] ビール追加フォームで「その他」選択→カスタム名入力→保存
- [x] 管理画面でビール編集時にカスタムスタイル名が保持される
- [x] ビール詳細でカスタムスタイル名が表示される
- [x] ビール一覧でカスタムスタイル名がバッジに表示される
- [x]  スタイル一覧に「その他」が表示されない
- [x]  /styles/{その他のID} へアクセスで404
- [x]  サイトマップに「その他」スタイルが含まれない