### PR TITLE
issue/43 ビールの購入リンク設置

### DIFF
--- a/src/app/admin/beers/BeerForm.tsx
+++ b/src/app/admin/beers/BeerForm.tsx
@@ -19,13 +19,17 @@ interface Beer {
   shortDescription: string | null;
   description: string | null;
   imageUrl: string | null;
+  amazonUrl: string | null;
+  rakutenUrl: string | null;
+  officialUrl: string | null;
+  otherShopUrl: string | null;
   status: string;
 }
 
 interface Props {
   beer?: Beer;
   breweries: { id: number; name: string }[];
-  styles: { id: number; name: string }[];
+  styles: { id: number; name: string; otherNames: string[] }[];
 }
 
 export function BeerForm({ beer, breweries, styles }: Props) {
@@ -56,6 +60,10 @@ export function BeerForm({ beer, breweries, styles }: Props) {
   const [imageUrl, setImageUrl] = useState<string | null>(
     beer?.imageUrl || null
   );
+  const [amazonUrl, setAmazonUrl] = useState(beer?.amazonUrl || "");
+  const [rakutenUrl, setRakutenUrl] = useState(beer?.rakutenUrl || "");
+  const [officialUrl, setOfficialUrl] = useState(beer?.officialUrl || "");
+  const [otherShopUrl, setOtherShopUrl] = useState(beer?.otherShopUrl || "");
   const [isUploading, setIsUploading] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -83,6 +91,10 @@ export function BeerForm({ beer, breweries, styles }: Props) {
         shortDescription: shortDescription || null,
         description: description || null,
         imageUrl,
+        amazonUrl: amazonUrl || null,
+        rakutenUrl: rakutenUrl || null,
+        officialUrl: officialUrl || null,
+        otherShopUrl: otherShopUrl || null,
       };
 
       const result = isEdit
@@ -283,6 +295,79 @@ export function BeerForm({ beer, breweries, styles }: Props) {
           onUploadingChange={setIsUploading}
           currentImageUrl={imageUrl}
         />
+      </fieldset>
+
+      {/* 購入リンク */}
+      <fieldset className="fieldset bg-base-200 border-base-300 rounded-box border p-4">
+        <legend className="fieldset-legend">購入リンク</legend>
+
+        <div className="space-y-4">
+          {/* Official URL */}
+          <div>
+            <label htmlFor="beer-official-url" className="label">
+              <span className="text-base label-text">公式サイト URL</span>
+            </label>
+            <input
+              id="beer-official-url"
+              type="url"
+              value={officialUrl}
+              onChange={(e) => setOfficialUrl(e.target.value)}
+              className="w-full input input-bordered"
+              placeholder="https://..."
+            />
+          </div>
+
+          {/* Amazon URL */}
+          <div>
+            <label htmlFor="beer-amazon-url" className="label">
+              <span className="text-base label-text">Amazon URL</span>
+            </label>
+            <input
+              id="beer-amazon-url"
+              type="url"
+              value={amazonUrl}
+              onChange={(e) => setAmazonUrl(e.target.value)}
+              className="w-full input input-bordered"
+              placeholder="https://www.amazon.co.jp/..."
+            />
+            <p className="text-sm text-base-content/60 mt-1">
+              アフィリエイトリンクを含む完全なURLを入力
+            </p>
+          </div>
+
+          {/* Rakuten URL */}
+          <div>
+            <label htmlFor="beer-rakuten-url" className="label">
+              <span className="text-base label-text">楽天 URL</span>
+            </label>
+            <input
+              id="beer-rakuten-url"
+              type="url"
+              value={rakutenUrl}
+              onChange={(e) => setRakutenUrl(e.target.value)}
+              className="w-full input input-bordered"
+              placeholder="https://item.rakuten.co.jp/..."
+            />
+            <p className="text-sm text-base-content/60 mt-1">
+              アフィリエイトリンクを含む完全なURLを入力
+            </p>
+          </div>
+
+          {/* Other Shop URL */}
+          <div>
+            <label htmlFor="beer-other-shop-url" className="label">
+              <span className="text-base label-text">その他のサイト URL</span>
+            </label>
+            <input
+              id="beer-other-shop-url"
+              type="url"
+              value={otherShopUrl}
+              onChange={(e) => setOtherShopUrl(e.target.value)}
+              className="w-full input input-bordered"
+              placeholder="https://..."
+            />
+          </div>
+        </div>
       </fieldset>
 
       {/* ボタン */}

--- a/src/app/admin/beers/actions.ts
+++ b/src/app/admin/beers/actions.ts
@@ -34,6 +34,10 @@ interface BeerInput {
   shortDescription: string | null;
   description: string | null;
   imageUrl: string | null;
+  amazonUrl: string | null;
+  rakutenUrl: string | null;
+  officialUrl: string | null;
+  otherShopUrl: string | null;
 }
 
 // ビールの作成
@@ -65,6 +69,10 @@ export async function createBeer(input: BeerInput) {
       description: input.description,
       status: "approved",
       imageUrl: input.imageUrl,
+      amazonUrl: input.amazonUrl,
+      rakutenUrl: input.rakutenUrl,
+      officialUrl: input.officialUrl,
+      otherShopUrl: input.otherShopUrl,
     });
 
     revalidatePath("/admin/beers");
@@ -106,6 +114,10 @@ export async function updateBeer(beerId: number, input: BeerInput) {
         shortDescription: input.shortDescription,
         description: input.description,
         imageUrl: input.imageUrl,
+        amazonUrl: input.amazonUrl,
+        rakutenUrl: input.rakutenUrl,
+        officialUrl: input.officialUrl,
+        otherShopUrl: input.otherShopUrl,
         updatedAt: new Date(),
       })
       .where(eq(beers.id, beerId));

--- a/src/app/admin/breweries/BreweryForm.tsx
+++ b/src/app/admin/breweries/BreweryForm.tsx
@@ -17,6 +17,9 @@ interface Brewery {
   websiteUrl: string | null;
   imageUrl: string | null;
   imageSourceUrl: string | null;
+  amazonUrl: string | null;
+  rakutenUrl: string | null;
+  otherShopUrl: string | null;
   status: string;
 }
 
@@ -48,6 +51,9 @@ export function BreweryForm({ brewery, prefectures }: Props) {
   const [imageSourceUrl, setImageSourceUrl] = useState(
     brewery?.imageSourceUrl || ""
   );
+  const [amazonUrl, setAmazonUrl] = useState(brewery?.amazonUrl || "");
+  const [rakutenUrl, setRakutenUrl] = useState(brewery?.rakutenUrl || "");
+  const [otherShopUrl, setOtherShopUrl] = useState(brewery?.otherShopUrl || "");
   const [isUploading, setIsUploading] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -69,6 +75,9 @@ export function BreweryForm({ brewery, prefectures }: Props) {
         websiteUrl: websiteUrl || null,
         imageUrl,
         imageSourceUrl: imageSourceUrl || null,
+        amazonUrl: amazonUrl || null,
+        rakutenUrl: rakutenUrl || null,
+        otherShopUrl: otherShopUrl || null,
       };
 
       const result = isEdit
@@ -238,6 +247,64 @@ export function BreweryForm({ brewery, prefectures }: Props) {
             <p className="text-sm text-base-content/60 mt-1">
               外部サイトから画像を使用する場合、出典元のURLを入力してください
             </p>
+          </div>
+        </div>
+      </fieldset>
+
+      {/* 購入リンク */}
+      <fieldset className="fieldset bg-base-200 border-base-300 rounded-box border p-4">
+        <legend className="fieldset-legend">購入リンク</legend>
+
+        <div className="space-y-4">
+          {/* Amazon URL */}
+          <div>
+            <label htmlFor="brewery-amazon-url" className="label">
+              <span className="text-base label-text">Amazon URL</span>
+            </label>
+            <input
+              id="brewery-amazon-url"
+              type="url"
+              value={amazonUrl}
+              onChange={(e) => setAmazonUrl(e.target.value)}
+              className="w-full input input-bordered"
+              placeholder="https://www.amazon.co.jp/..."
+            />
+            <p className="text-sm text-base-content/60 mt-1">
+              アフィリエイトリンクを含む完全なURLを入力
+            </p>
+          </div>
+
+          {/* Rakuten URL */}
+          <div>
+            <label htmlFor="brewery-rakuten-url" className="label">
+              <span className="text-base label-text">楽天 URL</span>
+            </label>
+            <input
+              id="brewery-rakuten-url"
+              type="url"
+              value={rakutenUrl}
+              onChange={(e) => setRakutenUrl(e.target.value)}
+              className="w-full input input-bordered"
+              placeholder="https://item.rakuten.co.jp/..."
+            />
+            <p className="text-sm text-base-content/60 mt-1">
+              アフィリエイトリンクを含む完全なURLを入力
+            </p>
+          </div>
+
+          {/* Other Shop URL */}
+          <div>
+            <label htmlFor="brewery-other-shop-url" className="label">
+              <span className="text-base label-text">その他のサイト URL</span>
+            </label>
+            <input
+              id="brewery-other-shop-url"
+              type="url"
+              value={otherShopUrl}
+              onChange={(e) => setOtherShopUrl(e.target.value)}
+              className="w-full input input-bordered"
+              placeholder="https://..."
+            />
           </div>
         </div>
       </fieldset>

--- a/src/app/admin/breweries/BreweryForm.tsx
+++ b/src/app/admin/breweries/BreweryForm.tsx
@@ -164,7 +164,7 @@ export function BreweryForm({ brewery, prefectures }: Props) {
           {/* Webサイト */}
           <div>
             <label htmlFor="brewery-website" className="label">
-              <span className="text-base label-text">Webサイト</span>
+              <span className="text-base label-text">公式サイト URL</span>
             </label>
             <input
               id="brewery-website"
@@ -174,6 +174,9 @@ export function BreweryForm({ brewery, prefectures }: Props) {
               className="w-full input input-bordered"
               placeholder="https://..."
             />
+            <p className="text-sm text-base-content/60 mt-1">
+              詳細ページで「公式サイト」ボタンとしても表示されます
+            </p>
           </div>
         </div>
       </fieldset>

--- a/src/app/admin/breweries/[id]/edit/page.tsx
+++ b/src/app/admin/breweries/[id]/edit/page.tsx
@@ -31,6 +31,9 @@ export default async function EditBreweryPage({ params }: Props) {
       websiteUrl: breweries.websiteUrl,
       imageUrl: breweries.imageUrl,
       imageSourceUrl: breweries.imageSourceUrl,
+      amazonUrl: breweries.amazonUrl,
+      rakutenUrl: breweries.rakutenUrl,
+      otherShopUrl: breweries.otherShopUrl,
       status: breweries.status,
     })
     .from(breweries)

--- a/src/app/admin/breweries/actions.ts
+++ b/src/app/admin/breweries/actions.ts
@@ -33,6 +33,9 @@ interface BreweryInput {
   websiteUrl: string | null;
   imageUrl: string | null;
   imageSourceUrl: string | null;
+  amazonUrl: string | null;
+  rakutenUrl: string | null;
+  otherShopUrl: string | null;
 }
 
 // ブルワリーの作成
@@ -62,6 +65,9 @@ export async function createBrewery(input: BreweryInput) {
       websiteUrl: input.websiteUrl,
       imageUrl: input.imageUrl,
       imageSourceUrl: input.imageSourceUrl,
+      amazonUrl: input.amazonUrl,
+      rakutenUrl: input.rakutenUrl,
+      otherShopUrl: input.otherShopUrl,
       status: "approved",
     });
 
@@ -103,6 +109,9 @@ export async function updateBrewery(breweryId: number, input: BreweryInput) {
         websiteUrl: input.websiteUrl,
         imageUrl: input.imageUrl,
         imageSourceUrl: input.imageSourceUrl,
+        amazonUrl: input.amazonUrl,
+        rakutenUrl: input.rakutenUrl,
+        otherShopUrl: input.otherShopUrl,
         updatedAt: new Date(),
       })
       .where(eq(breweries.id, breweryId));

--- a/src/app/beers/[id]/page.tsx
+++ b/src/app/beers/[id]/page.tsx
@@ -361,6 +361,10 @@ async function BeerDetailPage({ beerId }: { beerId: number }) {
       ibu: beers.ibu,
       imageUrl: beers.imageUrl,
       customStyleText: beers.customStyleText,
+      amazonUrl: beers.amazonUrl,
+      rakutenUrl: beers.rakutenUrl,
+      officialUrl: beers.officialUrl,
+      otherShopUrl: beers.otherShopUrl,
       brewery: {
         id: breweries.id,
         name: breweries.name,
@@ -659,6 +663,67 @@ async function BeerDetailPage({ beerId }: { beerId: number }) {
           </div>
         )}
       </div>
+
+      {/* 購入リンク */}
+      {(beer.amazonUrl || beer.rakutenUrl || beer.officialUrl || beer.otherShopUrl) && (
+        <div className="mt-12 pt-8 border-t border-base-300">
+          <h2 className="text-xl font-bold mb-4">このビールを購入</h2>
+          <div className="flex flex-wrap gap-3">
+            {beer.officialUrl && (
+              <a
+                href={beer.officialUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-outline gap-2"
+              >
+                <span>公式サイト</span>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            )}
+            {beer.amazonUrl && (
+              <a
+                href={beer.amazonUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-outline gap-2"
+              >
+                <span>Amazon</span>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            )}
+            {beer.rakutenUrl && (
+              <a
+                href={beer.rakutenUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-outline gap-2"
+              >
+                <span>楽天</span>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            )}
+            {beer.otherShopUrl && (
+              <a
+                href={beer.otherShopUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-outline gap-2"
+              >
+                <span>その他</span>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* 関連ページへのリンク */}
       <div className="mt-12 pt-8 border-t border-base-300">

--- a/src/app/breweries/[id]/page.tsx
+++ b/src/app/breweries/[id]/page.tsx
@@ -81,6 +81,9 @@ export default async function BreweryDetailPage({ params }: Props) {
       websiteUrl: breweries.websiteUrl,
       imageUrl: breweries.imageUrl,
       imageSourceUrl: breweries.imageSourceUrl,
+      amazonUrl: breweries.amazonUrl,
+      rakutenUrl: breweries.rakutenUrl,
+      otherShopUrl: breweries.otherShopUrl,
       prefecture: {
         id: prefectures.id,
         name: prefectures.name,
@@ -246,6 +249,54 @@ export default async function BreweryDetailPage({ params }: Props) {
           )}
         </div>
       </div>
+
+      {/* 購入リンク */}
+      {(brewery.amazonUrl || brewery.rakutenUrl || brewery.otherShopUrl) && (
+        <div className="mb-12 pt-8 border-t border-base-300">
+          <h2 className="text-xl font-bold mb-4">このブルワリーのビールを購入</h2>
+          <div className="flex flex-wrap gap-3">
+            {brewery.amazonUrl && (
+              <a
+                href={brewery.amazonUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-outline gap-2"
+              >
+                <span>Amazon</span>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            )}
+            {brewery.rakutenUrl && (
+              <a
+                href={brewery.rakutenUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-outline gap-2"
+              >
+                <span>楽天</span>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            )}
+            {brewery.otherShopUrl && (
+              <a
+                href={brewery.otherShopUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-outline gap-2"
+              >
+                <span>その他</span>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* このブルワリーのビール */}
       <div>

--- a/src/app/breweries/[id]/page.tsx
+++ b/src/app/breweries/[id]/page.tsx
@@ -250,11 +250,52 @@ export default async function BreweryDetailPage({ params }: Props) {
         </div>
       </div>
 
+      {/* このブルワリーのビール */}
+      <div>
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-2xl font-bold">製造ビール</h2>
+          {breweryBeers.length > 0 && (
+            <Link
+              href={`/beers/brewery-${brewery.id}`}
+              className="btn btn-outline btn-sm"
+            >
+              すべて見る →
+            </Link>
+          )}
+        </div>
+        {breweryBeers.length > 0 ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            {breweryBeers.map((beer) => (
+              <BeerCard key={beer.id} beer={beer} />
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-12 bg-base-200 rounded-lg">
+            <p className="text-base-content/60">
+              このブルワリーのビールはまだ登録されていません
+            </p>
+          </div>
+        )}
+      </div>
+
       {/* 購入リンク */}
-      {(brewery.amazonUrl || brewery.rakutenUrl || brewery.otherShopUrl) && (
-        <div className="mb-12 pt-8 border-t border-base-300">
+      {(brewery.websiteUrl || brewery.amazonUrl || brewery.rakutenUrl || brewery.otherShopUrl) && (
+        <div className="mt-12 pt-8 border-t border-base-300">
           <h2 className="text-xl font-bold mb-4">このブルワリーのビールを購入</h2>
           <div className="flex flex-wrap gap-3">
+            {brewery.websiteUrl && (
+              <a
+                href={brewery.websiteUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-outline gap-2"
+              >
+                <span>公式サイト</span>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            )}
             {brewery.amazonUrl && (
               <a
                 href={brewery.amazonUrl}
@@ -297,34 +338,6 @@ export default async function BreweryDetailPage({ params }: Props) {
           </div>
         </div>
       )}
-
-      {/* このブルワリーのビール */}
-      <div>
-        <div className="flex items-center justify-between mb-6">
-          <h2 className="text-2xl font-bold">製造ビール</h2>
-          {breweryBeers.length > 0 && (
-            <Link
-              href={`/beers/brewery-${brewery.id}`}
-              className="btn btn-outline btn-sm"
-            >
-              すべて見る →
-            </Link>
-          )}
-        </div>
-        {breweryBeers.length > 0 ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {breweryBeers.map((beer) => (
-              <BeerCard key={beer.id} beer={beer} />
-            ))}
-          </div>
-        ) : (
-          <div className="text-center py-12 bg-base-200 rounded-lg">
-            <p className="text-base-content/60">
-              このブルワリーのビールはまだ登録されていません
-            </p>
-          </div>
-        )}
-      </div>
     </div>
   );
 }

--- a/src/lib/db/schema/beers.ts
+++ b/src/lib/db/schema/beers.ts
@@ -14,6 +14,10 @@ export const beers = pgTable("beers", {
   abv: decimal("abv", { precision: 4, scale: 2 }),
   ibu: integer("ibu"),
   imageUrl: text("image_url"),
+  amazonUrl: text("amazon_url"), // Amazon購入リンク（アフィリエイト）
+  rakutenUrl: text("rakuten_url"), // 楽天購入リンク（アフィリエイト）
+  officialUrl: text("official_url"), // 公式サイトURL
+  otherShopUrl: text("other_shop_url"), // その他のサイトURL
   status: text("status").default("approved").notNull(), // 'pending' | 'approved' | 'rejected'
   submittedBy: uuid("submitted_by").references(() => users.id),
   createdAt: timestamp("created_at").defaultNow().notNull(),

--- a/src/lib/db/schema/breweries.ts
+++ b/src/lib/db/schema/breweries.ts
@@ -11,6 +11,9 @@ export const breweries = pgTable("breweries", {
   websiteUrl: text("website_url"),
   imageUrl: text("image_url"),
   imageSourceUrl: text("image_source_url"), // 画像の参照元URL
+  amazonUrl: text("amazon_url"), // Amazonストアリンク
+  rakutenUrl: text("rakuten_url"), // 楽天ストアリンク
+  otherShopUrl: text("other_shop_url"), // その他のサイトURL
   status: text("status").default("approved").notNull(), // 'pending' | 'approved' | 'rejected'
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),


### PR DESCRIPTION
## 概要

ビールとブルワリーに購入リンク機能を追加し、ユーザーが各種ECサイトや公式ショップから購入できる導線を整備。

Closes #43

## 変更内容

### データベース

**beers テーブル**
- `amazon_url` - Amazon購入リンク
- `rakuten_url` - 楽天購入リンク
- `official_url` - 公式サイトURL
- `other_shop_url` - その他のサイトURL

**breweries テーブル**
- `official_shop_url` - 公式ショップURL（新規）
- `amazon_url` - Amazonストアリンク
- `rakuten_url` - 楽天ストアリンク
- `other_shop_url` - その他のサイトURL

※ブルワリーは既存の `website_url`（Webサイト）と `official_shop_url`（公式ショップ）を分離

### 管理画面

- ビール作成/編集フォームに「購入リンク」セクションを追加
- ブルワリー作成/編集フォームに「購入リンク」セクションを追加
- スタイル検索で別名（otherNames）による検索を修正

### 詳細ページ

- ビール詳細: レビューセクションの下に購入リンクボタンを表示
- ブルワリー詳細: 製造ビール一覧の下に購入リンクボタンを表示

### リンク表示順序

1. 公式サイト
2. Amazon
3. 楽天
4. その他

## 確認事項

- [x] スキーマ変更をDBに反映済み
- [x] ビール管理画面で購入リンクが入力できること
- [x] ブルワリー管理画面で購入リンクが入力できること
- [x] ビール詳細ページで購入リンクが表示されること
- [x] ブルワリー詳細ページで購入リンクが表示されること
- [x] 購入リンクが未設定の場合、セクション自体が非表示になること

